### PR TITLE
Added RevealJS slides component to dash.

### DIFF
--- a/recordm/customUI/dash/package.json
+++ b/recordm/customUI/dash/package.json
@@ -21,6 +21,7 @@
     "crypto-js": "^4.1.1",
     "handlebars": "^4.7.7",
     "lodash.debounce": "^4.0.8",
+    "reveal.js": "^4.6.1",
     "tailwindcss": "^3.0.23",
     "tippy.js": "^6.3.7",
     "traverse": "^0.6.7",

--- a/recordm/customUI/dash/src/collector.js
+++ b/recordm/customUI/dash/src/collector.js
@@ -86,6 +86,12 @@ function parseDashboard(raw_dashboard) {
                 "Mode" : ""
             }]
         },
+        "Slides": {
+            "Content" : "",
+            "SlidesCustomize": [{
+                "SlidesClasses" : ""
+            }]
+        },
         "ModalActivator" : {
             "ModalActivatorCustomize" : [{
                 "ModalActivatorClasses" : ""

--- a/recordm/customUI/dash/src/components/Board.vue
+++ b/recordm/customUI/dash/src/components/Board.vue
@@ -11,6 +11,7 @@
             <Calendar  v-if="item['Component'] === 'Calendar'"  :component="item" :key="i" />
             <List      v-if="item['Component'] === 'List'"      :component="item" :key="i" />
             <Activator v-if="item['Component'] === 'ModalActivator'" :component="item" :key="i" @show-modal="d => $emit('show-modal', d)"/>
+            <Slides    v-if="item['Component'] === 'Slides'"      :component="item" :key="i" />    
         </template>
     </div>
 </template>
@@ -25,10 +26,11 @@
     import List   from './List.vue'
     import Mermaid from './Mermaid.vue'
     import Activator from './Activator.vue'
-import Markdown from './Markdown.vue'
+    import Markdown from './Markdown.vue'
+    import Slides from './Slides.vue'
 
     export default {
-        components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Activator, Markdown },
+        components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Activator, Markdown, Slides },
         props: {
           board: Object
         },

--- a/recordm/customUI/dash/src/components/Modal.vue
+++ b/recordm/customUI/dash/src/components/Modal.vue
@@ -16,6 +16,7 @@
                                 <Filtro v-if="item['Component'] === 'Filter'" :component="item" :key="i" />
                                 <Calendar v-if="item['Component'] === 'Calendar'" :component="item" :key="i" />
                                 <List v-if="item['Component'] === 'List'" :component="item" :key="i" />
+                                <Slides v-if="item['Component'] === 'Slides'" :component="item" :key="i" />    
                             </template>
                         </div>
                         <div class="mt-2">
@@ -43,9 +44,10 @@ import Filtro from './Filter.vue';
 import Calendar from './Calendar.vue';
 import List from './List.vue';
 import Markdown from './Markdown.vue';
+import Slides from './Slides.vue';
 
 export default {
-    components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Markdown },
+    components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Markdown, Slides },
     props: {
         board: Object
     },

--- a/recordm/customUI/dash/src/components/Slides.vue
+++ b/recordm/customUI/dash/src/components/Slides.vue
@@ -1,0 +1,55 @@
+<!-- testing -->
+
+<template>
+    <div class="reveal aspect-video rounded-md" :classes="classes">
+        <div class="slides">
+            <section data-markdown>
+                <textarea data-template 
+                data-separator="---" 
+                data-separator-vertical="^--">
+                    {{ myContent }}
+                </textarea>
+            </section>
+        </div>
+    </div>
+</template>
+
+<script>
+import Reveal from 'reveal.js';
+import Markdown from 'reveal.js/plugin/markdown/markdown.esm.js';
+
+
+export default {
+    props: {
+        component: Object
+    },
+    computed: {
+        options() { return this.component['SlidesCustomize'][0] },
+        classes() { return this.options['SlidesClasses'] || "" },
+        myContent() { return this.component["Content"] },
+    },
+    mounted() {
+        let deck = new Reveal(
+            {
+                plugins: [Markdown],
+            })
+
+        deck.initialize({
+            embedded: true,
+            hash: true,
+            slideNumber: 'h/v'
+        })
+
+        console.log(deck.getPlugins())
+    },
+    umounted() {
+        Reveal.destroy()
+    }
+}
+</script>
+
+<style>
+@import url('~reveal.js/dist/reveal.css');
+@import url('~reveal.js/dist/theme/dracula.css');
+</style>
+


### PR DESCRIPTION
Uses markdown. Requires "npm i" due to new dependency (RevealJS). Vertical slide parsing currently not functional.