### PR TITLE
Added initial working version of Slides component for Dash customization.

### DIFF
--- a/recordm/customUI/dash/package.json
+++ b/recordm/customUI/dash/package.json
@@ -21,6 +21,7 @@
     "crypto-js": "^4.1.1",
     "handlebars": "^4.7.7",
     "lodash.debounce": "^4.0.8",
+    "reveal.js": "^4.6.1",
     "tailwindcss": "^3.0.23",
     "tippy.js": "^6.3.7",
     "traverse": "^0.6.7",

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="cobDashApp" class="h-full w-full">
     <div v-if="error || chooserError" class="text-center my-20 text-2xl "> {{ error }} <br> {{ chooserError }} </div>
-    <Dashboard v-else-if="activeDashKey" :dashboard="currentDashboard.dashboardProcessed" :menu="currentDashboard.menu" />
+    <Dashboard v-else-if="activeDashKey" :dashboard="currentDashboard.dashboardProcessed" :menu="currentDashboard.menu" @refresh="updateQueries"/>
 
     <Refresh :updating="processingFlag" @refresh="updateQueries" class="fixed top-16 left-1" />
   </div>

--- a/recordm/customUI/dash/src/collector.js
+++ b/recordm/customUI/dash/src/collector.js
@@ -89,7 +89,9 @@ function parseDashboard(raw_dashboard) {
         "Slides": {
             "Content" : "",
             "SlidesCustomize": [{
-                "SlidesClasses" : ""
+                "SlidesClasses" : "",
+                "ConcurrentScript":"",
+                "Arg": [{}]
             }]
         },
         "ModalActivator" : {

--- a/recordm/customUI/dash/src/collector.js
+++ b/recordm/customUI/dash/src/collector.js
@@ -86,6 +86,12 @@ function parseDashboard(raw_dashboard) {
                 "Mode" : ""
             }]
         },
+        "Slides": {
+            "Content" : "",
+            "SlidesCustomize": [{
+                "SlidesClasses" : ""
+            }]
+        },
         "ModalActivator" : {
             "ModalActivatorCustomize" : [{
                 "ModalActivatorClasses" : ""

--- a/recordm/customUI/dash/src/components/Board.vue
+++ b/recordm/customUI/dash/src/components/Board.vue
@@ -11,6 +11,7 @@
             <Calendar  v-if="item['Component'] === 'Calendar'"  :component="item" :key="i" />
             <List      v-if="item['Component'] === 'List'"      :component="item" :key="i" />
             <Activator v-if="item['Component'] === 'ModalActivator'" :component="item" :key="i" @show-modal="d => $emit('show-modal', d)"/>
+            <Slides    v-if="item['Component'] === 'Slides'"      :component="item" :key="i" />    
         </template>
     </div>
 </template>
@@ -25,10 +26,11 @@
     import List   from './List.vue'
     import Mermaid from './Mermaid.vue'
     import Activator from './Activator.vue'
-import Markdown from './Markdown.vue'
+    import Markdown from './Markdown.vue'
+    import Slides from './Slides.vue'
 
     export default {
-        components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Activator, Markdown },
+        components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Activator, Markdown, Slides },
         props: {
           board: Object
         },

--- a/recordm/customUI/dash/src/components/Board.vue
+++ b/recordm/customUI/dash/src/components/Board.vue
@@ -11,7 +11,7 @@
             <Calendar  v-if="item['Component'] === 'Calendar'"  :component="item" :key="i" />
             <List      v-if="item['Component'] === 'List'"      :component="item" :key="i" />
             <Activator v-if="item['Component'] === 'ModalActivator'" :component="item" :key="i" @show-modal="d => $emit('show-modal', d)"/>
-            <Slides    v-if="item['Component'] === 'Slides'"      :component="item" :key="i" />    
+            <Slides    v-if="item['Component'] === 'Slides'"      :component="item" :key="i" v-on="$listeners"/>    
         </template>
     </div>
 </template>

--- a/recordm/customUI/dash/src/components/Dashboard.vue
+++ b/recordm/customUI/dash/src/components/Dashboard.vue
@@ -8,7 +8,7 @@
             <div :class="width + ' ' + grid" >
                 <template  v-for="(board,i) in boards">
                     <Modal v-if="isModal(board) && board.Board == activeModal" :board="board" :key="board.instanceId + '-modal-' + i"  @show-modal="toggleModal" />
-                    <Board v-else-if="!isModal(board)" :board="board" :key="board.instanceId + '-' + i" @show-modal="toggleModal" />
+                    <Board v-else-if="!isModal(board)" :board="board" :key="board.instanceId + '-' + i" @show-modal="toggleModal" v-on="$listeners"/>
                 </template>
             </div>
         </div>

--- a/recordm/customUI/dash/src/components/Modal.vue
+++ b/recordm/customUI/dash/src/components/Modal.vue
@@ -16,6 +16,7 @@
                                 <Filtro v-if="item['Component'] === 'Filter'" :component="item" :key="i" />
                                 <Calendar v-if="item['Component'] === 'Calendar'" :component="item" :key="i" />
                                 <List v-if="item['Component'] === 'List'" :component="item" :key="i" />
+                                <Slides v-if="item['Component'] === 'Slides'" :component="item" :key="i" />    
                             </template>
                         </div>
                         <div class="mt-2">
@@ -43,9 +44,10 @@ import Filtro from './Filter.vue';
 import Calendar from './Calendar.vue';
 import List from './List.vue';
 import Markdown from './Markdown.vue';
+import Slides from './Slides.vue';
 
 export default {
-    components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Markdown },
+    components: { Label, Menu, Totals, Kibana, Filtro, Calendar, List, Mermaid, Markdown, Slides },
     props: {
         board: Object
     },

--- a/recordm/customUI/dash/src/components/Slides.vue
+++ b/recordm/customUI/dash/src/components/Slides.vue
@@ -1,14 +1,20 @@
 
 <template>
-    <div class="reveal aspect-video rounded-md" :classes="classes">
-        <div class="slides">
-            <section data-markdown>
-                <textarea data-template 
-                data-separator="---" 
-                data-separator-vertical="^--">
-                    {{ myContent }}
+    <div :class="classes">
+        <div class="reveal aspect-video rounded-md" :id="slide_id">
+            <div class="slides">
+                <section ref="markdownContent" data-markdown>
+                    <textarea data-template data-separator="---" data-separator-vertical="^--">
+                    {{ this.markdownContent }}
                 </textarea>
-            </section>
+                </section>
+            </div>
+        </div>
+        <div v-if="reachedEnd" :class="'items-center pt-[1vh]'">
+            <button v-if="reachedEnd" v-on:click="confirmContentVisualization"
+                :class="[button_classes, { 'cursor-pointer': 'pointer' }]">
+                Mark as Seen
+            </button>
         </div>
     </div>
 </template>
@@ -16,37 +22,132 @@
 <script>
 import Reveal from 'reveal.js';
 import Markdown from 'reveal.js/plugin/markdown/markdown.esm.js';
-
+import axios from 'axios';
+const concurrent_dir = "/integrationm/concurrent/"
+const loading_message = "### Loading Content"
 
 export default {
     props: {
         component: Object
     },
+    data: () => ({
+        reachedEnd: false,
+        myDeck: null,
+        status: "loading",
+    }),
     computed: {
         options() { return this.component['SlidesCustomize'][0] },
         classes() { return this.options['SlidesClasses'] || "" },
-        myContent() { return this.component["Content"] },
+        button_classes() {
+            return `transition ease-in-out duration-300 
+            rounded-md border border-green-600 border-2 border-gray-600 
+            shadow-sm transform hover:translate-x-0.5 p-2 bg-emerald-300 hover:bg-emerald-500`
+        },
+
+        // To use a single direct content
+        //markdownContent() { return this.component["Content"] || "### Loading Content" },
+        markdownContent: {
+            get() {
+                return this.component["Content"] || loading_message
+            },
+            set(newValue) {
+                this.component['Content'] = newValue
+            }
+        },
+
+        // Used for multiple presentations compatibility in same page if necessary
+        slide_id() { return "slidesId-" + Date.now().toString() + (Math.random() + 1).toString(36).substring(7) },
+
+        concurrentScript() { return this.component["SlidesCustomize"][0]["ConcurrentScript"] },
+        concurrentArgs() { return this.component['SlidesCustomize'][0]['Arg'] || {} }
+    },
+    methods: {
+        callConcurrentScript() {
+            let args = {}
+            args['myArguments'] = this.concurrentArgs.map(myArg => {
+                return myArg['Arg']
+            })
+            axios.post(concurrent_dir + this.concurrentScript, args).then(res => {
+                this.$emit('refresh')
+            }).catch(e => {
+                throw (e)
+            })
+        },
+        prepareReveal() {
+            if (this.myDeck) {
+                this.myDeck.destroy()
+            }
+            // Reveal does DOM manipulation, so we need to "recreate" the original
+            // DOM structure so that Reveal can find it, and re-parse and create
+            // the presentation with the actual markdown content
+            const markdownContainer = document.getElementById(this.slide_id)
+            markdownContainer.innerHTML = `<div class="slides">
+                <section ref="markdownContent" data-markdown>
+                    <textarea data-template data-separator="---" data-separator-vertical="^--">
+                        ${this.markdownContent}
+                    </textarea>
+                </section>`
+
+            let q_selector = "#" + this.slide_id
+            this.myDeck = new Reveal(document.querySelector(q_selector),
+                {
+                    plugins: [Markdown],
+                })
+
+            if (this.concurrentScript) {
+                this.myDeck.on('slidetransitionend', event => {
+                    if (this.myDeck.getProgress() == 1 && !this.reachedEnd) {
+                        this.reachedEnd = true
+                    }
+                })
+            }
+
+            this.myDeck.initialize({
+                embedded: true,
+                slideNumber: 'h/v',
+                keyboardCondition: 'focused'
+            })
+        },
+        // Confirm content visualization
+        confirmContentVisualization() {
+            this.callConcurrentScript()
+            this.status = "confirmingVisualization"
+            this.markdownContent = this.loading_message
+            setTimeout(() => {
+                this.$emit('refresh')
+            }, 1500)
+        },
+    },
+    watch: {
+        markdownContent(newContent, oldContent) {
+            if (oldContent != newContent && newContent.trim() != "" && newContent != loading_message) {
+                this.prepareReveal()
+                this.status = "loaded"
+                this.reachedEnd = false
+            }
+        },
+        status(nc, oc) {
+        }
     },
     mounted() {
-        let deck = new Reveal(
-            {
-                plugins: [Markdown],
-            })
-
-        deck.initialize({
-            embedded: true,
-            hash: true,
-            slideNumber: 'h/v'
-        })
+        this.prepareReveal()
     },
-    umounted() {
-        Reveal.destroy()
+    unmount() {
+        this.myDeck.destroy()
     }
 }
 </script>
 
 <style>
 @import url('~reveal.js/dist/reveal.css');
-@import url('~reveal.js/dist/theme/dracula.css');
+@import url('~reveal.js/dist/theme/moon.css');
+
+.slide-number {
+    z-index: 2;
+}
+
+.controls {
+    z-index: 2;
+}
 </style>
 

--- a/recordm/customUI/dash/src/components/Slides.vue
+++ b/recordm/customUI/dash/src/components/Slides.vue
@@ -1,0 +1,52 @@
+
+<template>
+    <div class="reveal aspect-video rounded-md" :classes="classes">
+        <div class="slides">
+            <section data-markdown>
+                <textarea data-template 
+                data-separator="---" 
+                data-separator-vertical="^--">
+                    {{ myContent }}
+                </textarea>
+            </section>
+        </div>
+    </div>
+</template>
+
+<script>
+import Reveal from 'reveal.js';
+import Markdown from 'reveal.js/plugin/markdown/markdown.esm.js';
+
+
+export default {
+    props: {
+        component: Object
+    },
+    computed: {
+        options() { return this.component['SlidesCustomize'][0] },
+        classes() { return this.options['SlidesClasses'] || "" },
+        myContent() { return this.component["Content"] },
+    },
+    mounted() {
+        let deck = new Reveal(
+            {
+                plugins: [Markdown],
+            })
+
+        deck.initialize({
+            embedded: true,
+            hash: true,
+            slideNumber: 'h/v'
+        })
+    },
+    umounted() {
+        Reveal.destroy()
+    }
+}
+</script>
+
+<style>
+@import url('~reveal.js/dist/reveal.css');
+@import url('~reveal.js/dist/theme/dracula.css');
+</style>
+


### PR DESCRIPTION
Uses markdown content to create an interactive slides presentation.
Supports arrow-keys interaction, fullscreen (F) and an overview mode (O) by default.

Supports sequential content conditionalism through the call of a concurrent script when content is 'marked as seen' when reaching the end of the presentation.

Dashboard Definition requires the new fields added to the collector.js

Requires "npm i" and build (when deployed) due to new dependency (Reveal.js)

Vertical slides parsing currently not functional.
