### PR TITLE
y-scroll fix in modal, and added tab escaping in dashboard build

### DIFF
--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -392,6 +392,7 @@
               .replaceAll(/,\s*]/g, "]").replaceAll(/,\s*]/g, "]").replaceAll(/,\s*]/g, "]").replaceAll(/,\s*]/g, "]") // Every last comma in array are removed. Ssupport UP TO 3 consequently commas
               .replaceAll(/(,(\s*))+/g, ",$2") //  Also remove double comma in the resulting arrays (maintain the spaces in case normal text with commas)
               .replaceAll(/(?<!\\)\n/g, "\\n") // escapes newlines
+              .replaceAll(/	/g,"\\t") //escapes literal tabs
           )
 
           for( let i = dashboard.boardQueries.length; i > 0 ; i-- ) {

--- a/recordm/customUI/dash/src/components/Modal.vue
+++ b/recordm/customUI/dash/src/components/Modal.vue
@@ -4,7 +4,7 @@
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
             <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
                 <div class="flex min-h-full  items-center justify-center text-center ">
-                    <div :class="`relative transform shadow-xl transition-all p-4 overflow-y-scroll ${this.classes}`">
+                    <div :class="`relative transform shadow-xl transition-all p-4 ${this.classes}`">
                         <template v-for="(item, i) in components">
                             <Markdown v-if="item['Component'] === 'Markdown'" :component="item" :key="i" />
                             <Mermaid v-if="item['Component'] === 'Mermaid'" :component="item" :key="i" />
@@ -52,7 +52,7 @@ export default {
     computed: {
         options() { return this.board['BoardCustomize'][0] },
         components() { return this.board['Component'] },
-        classes() { return this.options['BoardClasses'] || "min-w-[80%] h-[70vh] rounded-lg bg-white text-left" },
+        classes() { return this.options['BoardClasses'] || "min-w-[80%] h-[70vh] rounded-lg bg-white text-left overflow-y-scroll" },
         boards() { return this.dashboard['Board'] },
     },
     mounted() {


### PR DESCRIPTION
- Small fix to y-scroll in modal. moved 'overflow-y-scroll' to default classes instead of it being hardcoded
- Added literal tab escaping in dashboard build, when parsing the entire dashboard json string