### PR TITLE
added a feature to allow the client to search only for events that intersect with the current month in the calendar

### DIFF
--- a/recordm/customUI/dash/src/collector.js
+++ b/recordm/customUI/dash/src/collector.js
@@ -172,7 +172,8 @@ function parseDashboard(raw_dashboard) {
                 "MaxVisibleDayEvents": "",
                 "AllowCreateInstances":"",
                 "CreateDefinition":"",
-                "EventViews":""
+                "EventViews":"",
+                "StrictMode":""
             }],
             "Events": [{
                 "Definition": "",

--- a/recordm/customUI/dash/src/components/Calendar.vue
+++ b/recordm/customUI/dash/src/components/Calendar.vue
@@ -176,19 +176,23 @@
 
       queries() {
         let queries = []
-        if (this.dateRange && this.initialDate) { // Only calculate queries after having a dateRange set by the calendar
-          for(let i in this.eventSources) {  
-            if (this.strictMode && "dayGridMonth" === this.currentActiveView ){ //check if the grid view is dayMonthGridView
-              if (this.dateRange[0].getMonth() < this.initialDate.getMonth()) {
-                this.dateRange[0] = (new Date(this.dateRange[0].getFullYear(), this.initialDate.getMonth()))
-              }
-              if (this.dateRange[1].getMonth() > this.initialDate.getMonth()) {
-                this.dateRange[1] = (new Date(this.dateRange[1].getFullYear(),this.initialDate.getMonth()+1,0))
-                this.dateRange[1].setHours(23,59,59);
-              } 
+        
+        if (this.dateRange) { // Only calculate queries after having a dateRange set by the calendar
+          
+          if (this.initialDate && this.strictMode && "dayGridMonth" === this.currentActiveView ){ //check if the grid view is dayMonthGridView
+            if (this.dateRange[0].getMonth() < this.initialDate.getMonth()) {
+              this.dateRange[0] = (new Date(this.dateRange[0].getFullYear(), this.initialDate.getMonth()))
             }
-            let startDate = this.dateRange[0].getTime()
-            let endDate = this.dateRange[1].getTime()
+            if (this.dateRange[1].getMonth() > this.initialDate.getMonth()) {
+              this.dateRange[1] = (new Date(this.dateRange[1].getFullYear(),this.initialDate.getMonth()+1,0))
+              this.dateRange[1].setHours(23,59,59);
+            } 
+          }
+
+          let startDate = this.dateRange[0].getTime()
+          let endDate = this.dateRange[1].getTime()
+          
+          for(let i in this.eventSources) {  
             // Calculate date range query part
             let startField = toEsFieldName(this.eventSources[i]['DateStartEventField'])
             let endField   = toEsFieldName(this.eventSources[i]['DateEndEventField'])


### PR DESCRIPTION
This change requires that a field `StrictMode`with the keyword `$[TRUE,FALSE] $default(FALSE)` and optional description of `When in mode dayGridWeek, it tells the calendar to include in the query only the days of the current month in the calendar, instead of all the visible months` must be added in the definition **Dashboard_V1** under the section **CalendarCustomize**