### PR TITLE
Fix kibana output filter when user selects this week or this day

### DIFF
--- a/recordm/customUI/dash/src/components/Kibana.vue
+++ b/recordm/customUI/dash/src/components/Kibana.vue
@@ -92,8 +92,16 @@
                   let maxDate = Date.parse(event.data.time.max)
                   if (isNaN(maxDate)) maxDate = event.data.time.max.replace('/', '\\/')
 
-                  if (event.data.time.min) timeQuery += `${this.kibanaTimeField}.date:>=${minDate} `;
-                  if (event.data.time.max) timeQuery += `${this.kibanaTimeField}.date:<${maxDate} `;
+                  // Aparently when filtering results like 'today, this week' what kibana is doing is "<="
+                  const includeMaxDateResults = minDate === maxDate
+
+                  // Keep it retro compatible
+                  const timeField = this.kibanaTimeField.trim().endsWith(".date")
+                      ? this.kibanaTimeField.trim()
+                      : this.kibanaTimeField.trim() + ".date"
+
+                  if (event.data.time.min) timeQuery += `${timeField}:>=${minDate} `;
+                  if (event.data.time.max) timeQuery += `${timeField}:${includeMaxDateResults ? '<=' : '<'}${maxDate} `;
                 }
 
                 // Só vale a pena reagir aos eventos de mudança de filtro no Kibana

--- a/recordm/customUI/dash/src/components/Kibana.vue
+++ b/recordm/customUI/dash/src/components/Kibana.vue
@@ -92,16 +92,18 @@
                   let maxDate = Date.parse(event.data.time.max)
                   if (isNaN(maxDate)) maxDate = event.data.time.max.replace('/', '\\/')
 
-                  // Aparently when filtering results like 'today, this week' what kibana is doing is "<="
-                  const includeMaxDateResults = minDate === maxDate
-
                   // Keep it retro compatible
                   const timeField = this.kibanaTimeField.trim().endsWith(".date")
                       ? this.kibanaTimeField.trim()
                       : this.kibanaTimeField.trim() + ".date"
 
-                  if (event.data.time.min) timeQuery += `${timeField}:>=${minDate} `;
-                  if (event.data.time.max) timeQuery += `${timeField}:${includeMaxDateResults ? '<=' : '<'}${maxDate} `;
+                  if (minDate === maxDate) {
+                    if (event.data.time.min) timeQuery += `${timeField}:${minDate} `;
+
+                  } else {
+                    if (event.data.time.min) timeQuery += `${timeField}:>=${minDate} `;
+                    if (event.data.time.max) timeQuery += `${timeField}:<${maxDate} `;
+                  }
                 }
 
                 // Só vale a pena reagir aos eventos de mudança de filtro no Kibana


### PR DESCRIPTION
The way the query was built it wouldn't return any values because all records would be excluded when lower than date. if both start date and end date are the same then it must lower then and equals to .