### PR TITLE
Fix only appearing first kind of  event in calendar.

### DIFF
--- a/recordm/customUI/dash/src/components/Calendar.vue
+++ b/recordm/customUI/dash/src/components/Calendar.vue
@@ -228,7 +228,7 @@
       queries: function(newQueries) {
         this.calendarApi.setOption('noEventsContent', {html: '<div>&nbsp;</div>'})
         for (var i=0; i<newQueries.length; i++) {
-          if(this.rmEventSources.length) {
+          if(this.rmEventSources.length < i) {
             this.rmEventSources[i].changeArgs({query: newQueries[i]})
           } else {
             this.rmEventSources.push( instancesList( this.eventSources[i]['Definition'], newQueries[i], 800, 0, "", {validity: 60}) )              


### PR DESCRIPTION
Existence of a query in calendar was not being properly checked, and as such only the first event was being displayed, the others were having a null pointer.