### PR TITLE
Prevents rendering when fetching context query objects from cache

### DIFF
--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -575,6 +575,15 @@
 
           // Build final context with all components
           let context = specifiedContext || {}
+
+          //IMPORTANT: this does not work for httpGet and httpPost
+          const keys = Object.keys(context)
+          for (const index in keys) {
+            const key = keys[index]
+            if (dashboard.dashboardContext && dashboard.dashboardContext[key] && (context[key].results.value || JSON.stringify(context[key]) &&  JSON.stringify(dashboard.dashboardContext[key]) )  ) {
+              context[key] = dashboard.dashboardContext[key]
+            }
+          }
           context = { dashboardId: dashboard.id, ...baseContext, ...context }
           // Add a copy of dashboardsRequested result in case we need Chooser to display alternatives
           context.dashboards = this.dashboardsRequested.value.slice().reverse();


### PR DESCRIPTION
When fetching objects from cache, objects related to the queries in the context such as list and distinct, it returns the previous instances of the objects if the cache was a hit. This prevents Vue from having to re-render the boards because the instances of the objects do not change.