### PR TITLE
Dragdrop highlight mode

### DIFF
--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -669,23 +669,39 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
         }
 
         activeDragDropInfo.handleDragEnter = function (e) {
-          if (e && e.target && e.target.classList.contains("dropZone")) {
-            // We leave this blank to easily support adding new logic to drag and drop.
+          if (e && e.target) { 
+            if(e.target.classList && e.target.classList.contains("dropZone")) {
+              if(e.target.classList.contains("dropZoneHighlight") && activeDragDropInfo.draggedItem) {
+                e.target.classList.remove("bg-stone-200")
+                e.target.classList.add("bg-stone-400")
+              }
+            }
           }
         }
 
         activeDragDropInfo.handleDragLeave = function (e) {
-          if (e && e.target && e.fromElement.classList && !e.fromElement.classList.contains("dragItem")) {
-            // We leave this blank to easily support adding new logic to drag and drop.
+          if (e && e.target) {
+            if (e.target.classList && e.target.classList.contains("dropZone")) {
+              if (e.target.classList.contains("dropZoneHighlight") && activeDragDropInfo.draggedItem) {
+                e.target.classList.add("bg-stone-200")
+                e.target.classList.remove("bg-stone-400")
+              }
+            }
+
           }
         }
 
         activeDragDropInfo.handleDragOver = function(e, dropZone) {
           e.preventDefault();
           e.dataTransfer.dropEffect = "move"
-          activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
-          activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
+          if(dropZone.classList.contains("dropZoneHighlight")) {
+            // We do nothing for now. We leave this blank for future logic (?)
+          } else {
+            activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
+            activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
+          }
         }
+
 
         activeDragDropInfo.handleDragDrop = function (e, dropZone) {
           e.preventDefault();
@@ -711,6 +727,11 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
                   activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
                   activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
                   activeDragDropInfo.draggedItem.classList.remove("dragging")
+                  if (dropZone.classList.contains("dropZoneHighlight")) {
+                    activeDragDropInfo.draggedItem.classList.add("hidden")
+                    dropZone.classList.remove("bg-stone-400") 
+                    dropZone.classList.add("bg-stone-200") 
+                  }
                   activeDragDropInfo.droppedOnZone = true;
                 })
                 .catch(error => {
@@ -726,6 +747,11 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
                   activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
                   activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint, true)
                   activeDragDropInfo.draggedItem.classList.remove("dragging")
+                  if (dropZone.classList.contains("dropZoneHighlight")) {
+                    activeDragDropInfo.draggedItem.classList.add("hidden")
+                    dropZone.classList.remove("bg-stone-400") 
+                    dropZone.classList.add("bg-stone-200") 
+                  }
                   activeDragDropInfo.droppedOnZone = true;
             }
           }

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -710,13 +710,15 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
             // Parse dropzone data and classes
             let dropZone_data_attributes = activeDragDropInfo.parseDataFields(dropZone.attributes)
             let dropZone_class_data_attributes = activeDragDropInfo.parseClasses(dropZone.classList)
+            let dropZone_html_attributes = {"dropZoneHTMLId" : dropZone.id || -1 }
             // Parse dragitem data and classes
             let dragItem_data_attributes = activeDragDropInfo.parseDataFields(activeDragDropInfo.draggedItem.attributes)
             let dragItem_class_data_attributes = activeDragDropInfo.parseClasses(activeDragDropInfo.draggedItem.classList)
 
             // Merge dictionaries and call concurrent
             let params = Object.assign(dropZone_data_attributes, dropZone_class_data_attributes,
-              dragItem_data_attributes, dragItem_class_data_attributes
+              dragItem_data_attributes, dragItem_class_data_attributes,
+              dropZone_html_attributes
             )
             // Get concurrent script name
             let concur_script = activeDash.dashboardParsed.DashboardCustomize[0].DragDropConcurrent

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -724,14 +724,13 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
               axios.post(`/integrationm/concurrent/${concur_script}`, params)
                 .then(() => {
                   // Concurrent 200
-                  activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
-                  activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
-                  activeDragDropInfo.draggedItem.classList.remove("dragging")
-                  if (dropZone.classList.contains("dropZoneHighlight")) {
-                    activeDragDropInfo.draggedItem.classList.add("hidden")
-                    dropZone.classList.remove("bg-stone-400") 
-                    dropZone.classList.add("bg-stone-200") 
+                  if (dropZone != activeDragDropInfo.srcZone && dropZone.classList.contains("dropZoneHighlight")) {
+                    dropZone.classList.remove("!bg-stone-400")
+                  } else {
+                    activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
+                    activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
                   }
+                  activeDragDropInfo.draggedItem.classList.remove("dragging")
                   activeDragDropInfo.droppedOnZone = true;
                 })
                 .catch(error => {
@@ -744,14 +743,13 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
                   }
                 })
             } else {
-                  activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
-                  activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint, true)
-                  activeDragDropInfo.draggedItem.classList.remove("dragging")
-                  if (dropZone.classList.contains("dropZoneHighlight")) {
-                    activeDragDropInfo.draggedItem.classList.add("hidden")
-                    dropZone.classList.remove("bg-stone-400") 
-                    dropZone.classList.add("bg-stone-200") 
+              if (dropZone != activeDragDropInfo.srcZone && dropZone.classList.contains("dropZoneHighlight")) {
+                    dropZone.classList.remove("!bg-stone-400")
+                  } else {
+                    activeDragDropInfo.dstZonePoint = activeDragDropInfo.getCurrentPoint(dropZone, e.clientY);
+                    activeDragDropInfo.putDraggedItemOn(dropZone, activeDragDropInfo.dstZonePoint)
                   }
+                  activeDragDropInfo.draggedItem.classList.remove("dragging")
                   activeDragDropInfo.droppedOnZone = true;
             }
           }


### PR DESCRIPTION
Now supports new dropZone class `dropZoneHighlight`. This keyword changes how the drag and drop behaves when dropping a dragItem on a dropZone marked with it: it no longer insers the dragitem in the dropzone (live preview) and doesnt remove it when dropping - akin to dragging a file to a file upload button.

When calling a concurrent, we now inject the dropzone's html element ID if it has one. this is useful because in some cases, such as when using Hierarchy, we can use this ID to refer to a specific instance listed - since we cant get that type of value using handlebars