### PR TITLE
Fixes localIterableEval vulnerability to invalid json

### DIFF
--- a/customize.js
+++ b/customize.js
@@ -1,3 +1,3 @@
 module.exports = {
-  version: "6.60.2"
+  version: "6.60.3"
 };

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -350,13 +350,14 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
   function localIterableEval(obj, evalCode, someOrEveryOrFilter,options={defaultValue:false}) {
     let filter = []
     for (const key in obj) {
-      const val = typeof obj[key] == 'object' ? JSON.stringify(obj[key]) : `'${obj[key]}'`
-      const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`   // evalCode example: "key != 'test' && val > 0"
-      const cleanedCode = code.replaceAll(/\\"/g,"\"").replaceAll(/\\'/g,"\'")
+      const val = typeof obj[key] === 'object' && obj[key] !== null
+        ? JSON.stringify(Object.fromEntries(Object.entries(obj[key]).map(([k, v]) => [k, JSON.stringify(v)])))
+        : `'${obj[key]}'`;      
+      const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`   
       let evalResult
       
       try {
-        evalResult = eval(cleanedCode)
+        evalResult = eval(code)
       } catch (e) {
         console.error("eval error of key:"+key+" and value:"+JSON.stringify(obj[key])+" --> ",e)
       }

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -348,12 +348,21 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
   }) 
 
   function localIterableEval(obj, evalCode, someOrEveryOrFilter,options={defaultValue:false}) {
+
+    const sanitizeForEval = (value) => {
+      if (typeof value === 'string') {
+        // Escape quotes, backslashes, and newlines to make the string safe for eval
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n')}'`;
+      } else if (typeof value === 'object' && value !== null) {
+        return JSON.stringify(value);  // Only JSON.stringify objects
+      }
+      return value;  // Return numbers, booleans, etc. directly
+    };
+
     let filter = []
     for (const key in obj) {
-      const val = typeof obj[key] === 'object' && obj[key] !== null
-        ? JSON.stringify(Object.fromEntries(Object.entries(obj[key]).map(([k, v]) => [k, JSON.stringify(v)])))
-        : `'${obj[key]}'`;      
-      const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`   
+      const val = sanitizeForEval(obj[key])
+      const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`  
       let evalResult
       
       try {

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -350,13 +350,13 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
   function localIterableEval(obj, evalCode, someOrEveryOrFilter,options={defaultValue:false}) {
     let filter = []
     for (const key in obj) {
-      const val = typeof obj[key] === 'object' ? JSON.stringify(obj[key]) : `'${obj[key]}'`
+      const val = typeof obj[key] == 'object' ? JSON.stringify(obj[key]) : `'${obj[key]}'`
+      evalCode = evalCode.replaceAll(/\\"/g,"\"").replaceAll(/\\'/g,"\'")
       const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`  
-      const cleanedCode = code.replaceAll(/\\"/g,"\"").replaceAll(/\\'/g,"\'")
       let evalResult
       
       try {
-        evalResult = eval(cleanedCode)
+        evalResult = eval(code)
       } catch (e) {
         console.error("eval error of key:"+key+" and value:"+JSON.stringify(obj[key])+" --> ",e)
       }

--- a/recordm/customUI/dash/src/App.vue
+++ b/recordm/customUI/dash/src/App.vue
@@ -348,25 +348,15 @@ Handlebars.registerHelper("pasteInRm", function (...strings) {
   }) 
 
   function localIterableEval(obj, evalCode, someOrEveryOrFilter,options={defaultValue:false}) {
-
-    const sanitizeForEval = (value) => {
-      if (typeof value === 'string') {
-        // Escape quotes, backslashes, and newlines to make the string safe for eval
-        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n')}'`;
-      } else if (typeof value === 'object' && value !== null) {
-        return JSON.stringify(value);  // Only JSON.stringify objects
-      }
-      return value;  // Return numbers, booleans, etc. directly
-    };
-
     let filter = []
     for (const key in obj) {
-      const val = sanitizeForEval(obj[key])
+      const val = typeof obj[key] === 'object' ? JSON.stringify(obj[key]) : `'${obj[key]}'`
       const code = `((key,val) =>  ${evalCode}) ('${key}', ${val})`  
+      const cleanedCode = code.replaceAll(/\\"/g,"\"").replaceAll(/\\'/g,"\'")
       let evalResult
       
       try {
-        evalResult = eval(code)
+        evalResult = eval(cleanedCode)
       } catch (e) {
         console.error("eval error of key:"+key+" and value:"+JSON.stringify(obj[key])+" --> ",e)
       }


### PR DESCRIPTION
We simply json stringify the object's properties (if its an object) before stringifying the entire object - since its inner properties may have text that is not valid json.