### PR TITLE
Fix potential error on early menu refresh

### DIFF
--- a/recordm/customUI/js/cob/_menus.js
+++ b/recordm/customUI/js/cob/_menus.js
@@ -159,7 +159,13 @@ cob.custom.customize.push(function (core, utils, _ui) {
          }})
       }
 
-      window.addEventListener("cobRefreshMenu", () => solutionDashInfo.update({force:true})) // event listener for requests from the dash app (when lastDash and lastDahsolution changes)    
+      window.addEventListener("cobRefreshMenu", () => {
+         if (solutionDashInfo && typeof solutionDashInfo.update === 'function') {
+            solutionDashInfo.update({force:true})
+         } else {
+            setTimeout(() => window.dispatchEvent(new Event("cobRefreshMenu")), 200)
+         }
+      }) // event listener for requests from the dash app (when lastDash and lastDashSolution changes)
       window.addEventListener('click', function(e) {   // event listener that closes submenus when there's clicks outside that submenu
          var subMenus = [...document.querySelectorAll('.cob-submenu')];
          subMenus.forEach(sm => { if (!sm.contains(e.target)) sm.removeAttribute('open') });


### PR DESCRIPTION
## Summary
- add guard in cob menu refresh event handler
- schedule retry when menu info not yet loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684ebcf75020833283a0bfff389b7e35