### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ custom-ui.items.home.label=Home
 custom-ui.items.home.url=dash
 ```
 
-After creating the definitions, import the follwing xls       
+After creating the definitions, import the following xls       
 ```
 1.dashboard-solutions.xlsx
 2.dashboard_v1.xlsx
-dashboard_chooser_0.28.0.xlsx (this one substitutes the chooser dashboard; delete manually the onde created by the 1st sheet) 
+dashboard_chooser_0.28.0.xlsx (this one substitutes the chooser dashboard; delete manually the one created by the 1st sheet) 
 ```
 
 


### PR DESCRIPTION
## Summary
- fix typos in README: `follwing` -> `following`, `onde` -> `one`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684ebee51e10833294f897d277bd2d96