### PR TITLE
Fix typo in _menus comment

### DIFF
--- a/recordm/customUI/js/cob/_menus.js
+++ b/recordm/customUI/js/cob/_menus.js
@@ -9,7 +9,7 @@ cob.custom.customize.push(function (core, utils, _ui) {
     * -------------------- -------------------- -------------------- --------------------
     Custom getDefaultModuleUri that returns last showed dashboard if it exists as entry page
 
-    Suports using lastDash overrides via `custom-info=last-dash-override` properties in web.properties
+    Supports using lastDash overrides via `custom-info=last-dash-override` properties in web.properties
     Spaces must be replaced by _ in the props.
     Example:
     custom-info=last-dash-override


### PR DESCRIPTION
## Summary
- fix comment in `_menus.js`

## Testing
- `grep -n "Supports" -n recordm/customUI/js/cob/_menus.js`

------
https://chatgpt.com/codex/tasks/task_b_684ebf26451c8332a4314275c075eb41