### PR TITLE
Upgrade Vue dashboard to Vue 3

### DIFF
--- a/recordm/customUI/dash/package.json
+++ b/recordm/customUI/dash/package.json
@@ -30,11 +30,12 @@
     "tesseract.js": "^5.1.1",
     "tippy.js": "^6.3.7",
     "traverse": "^0.6.7",
-    "vue": "^2.6.11",
-    "vue-cropperjs": "^4.2.0"
+    "vue": "^3.3.4",
+    "vue-cropperjs": "^5.0.0",
+    "mitt": "^3.0.0"
   },
   "devDependencies": {
-    "@vue/cli-service": "~4.5.0",
-    "vue-template-compiler": "^2.6.11"
+    "@vue/cli-service": "~5.0.0",
+    "@vue/compiler-sfc": "^3.3.4"
   }
 }

--- a/recordm/customUI/dash/src/components/Calendar.vue
+++ b/recordm/customUI/dash/src/components/Calendar.vue
@@ -29,6 +29,7 @@
   import rmListDefinitions from '@cob/rest-api-wrapper/src/rmListDefinitions';
   import tippy from 'tippy.js';
   import Instance from "@/components/shared/Instance";
+  import { createApp } from 'vue';
   import ComponentStatePersistence from "@/model/ComponentStatePersistence";
   import Handlebars from 'handlebars'
   import CalendarDayEvent from './CalendarDayEvent.vue'
@@ -679,7 +680,8 @@
             const template = Handlebars.compile(convertedToHandlebars)
             tooltipComponent = template(esInstance)
         } else {
-          tooltipComponent = new Vue(Object.assign({propsData: {esInstance}}, Instance)).$mount().$el
+          const container = document.createElement('div')
+          tooltipComponent = createApp(Instance, { esInstance }).mount(container).$el
         }
 
         return tippy(el, {

--- a/recordm/customUI/dash/src/components/Dashboard.vue
+++ b/recordm/customUI/dash/src/components/Dashboard.vue
@@ -64,7 +64,7 @@ export default {
         this.runLifecycleHook(this.customizations, "onBeforeDestroy")
 
         // Clear all events added by customizations and components before destroying
-        EventBus.$off()
+        EventBus.all.clear()
     },
     computed: {
         options() { return this.dashboard['DashboardCustomize'][0] },

--- a/recordm/customUI/dash/src/components/ImageViewer.vue
+++ b/recordm/customUI/dash/src/components/ImageViewer.vue
@@ -310,7 +310,7 @@ export default {
                     componentIdentifier: this.componentIdentifier,
                     details: { ocrText: this.ocrText, cropData: this.currCropData, confidence: ocrData.data.confidence }
                 }
-                EventBus.$emit("imageviewer-ocr", eventDetails)
+                EventBus.emit("imageviewer-ocr", eventDetails)
             } catch (exce) {
                 console.log("Error running OCR: ", exce)
             } finally {

--- a/recordm/customUI/dash/src/components/InstanceViewer.vue
+++ b/recordm/customUI/dash/src/components/InstanceViewer.vue
@@ -104,7 +104,7 @@ export default {
                   componentIdentifier: this.componentIdentifier,
                   detail: fieldDetails
                 }
-                EventBus.$emit(BUS_FIELD_FOCUS, eventDetails);
+                EventBus.emit(BUS_FIELD_FOCUS, eventDetails);
               };
 
               input.addEventListener("focus", focusHandler);

--- a/recordm/customUI/dash/src/event-bus.js
+++ b/recordm/customUI/dash/src/event-bus.js
@@ -1,2 +1,3 @@
-import Vue from 'vue';
-export const EventBus = new Vue();
+import mitt from 'mitt'
+
+export const EventBus = mitt();

--- a/recordm/customUI/dash/src/main.js
+++ b/recordm/customUI/dash/src/main.js
@@ -1,11 +1,11 @@
-import Vue from "vue";
+import { createApp } from "vue";
 import App from "./App.vue";
 
 window.CoBDasHDebug = window.CoBDasHDebug || {}
 const DEBUG = window.CoBDasHDebug
 // window.CoBDasHDebug.main = true
 
-Vue.config.productionTip = true;
+// Vue 3 does not expose productionTip
 
 if(DEBUG.main) console.log("DASH: MAIN: 0 location.hash=" + window.location.hash);
 
@@ -47,9 +47,8 @@ function loadVueApp(origin) {
             document.querySelector("section.custom-resource").append(newcobDashAppDiv)
         }
         
-        vueApp = new Vue({
-            render: function(h) { return h(App); },
-        }).$mount("#cobDashApp");
+        vueApp = createApp(App)
+        vueApp.mount("#cobDashApp")
         window.cobDashAppLoaded = true
         if(DEBUG.main) console.log("DASH: MAIN: " + origin + ".3: done");
     } else {
@@ -62,7 +61,7 @@ function onHashChange() {
 
     if (currentDashName !== initialDashName && window.cobDashAppLoaded) {
         if(DEBUG.main) console.log("DASH: MAIN: 9: Leaving the initialDashName=",initialDashName," for currentDashName=",currentDashName,". Destroying the dashboard");
-        vueApp.$destroy();
+        vueApp.unmount();
         cobDashAppLoaded = false
     } 
     

--- a/recordm/customUI/dash/vue.config.js
+++ b/recordm/customUI/dash/vue.config.js
@@ -21,6 +21,13 @@ if(!process.env.dash_dir || !SERVER) {
 }
 
 module.exports = {
+  configureWebpack: {
+    resolve: {
+      alias: {
+        'vue': '@vue/compat'
+      }
+    }
+  },
   // temos que fixar o directorio onde colocamos o build,
   //  para podermos usar o dashboard.html que é gerado sem o editar
   // NOTA: o path relativo não funciona bem com o npm run serve


### PR DESCRIPTION
## Summary
- migrate project to Vue 3 using compat build
- switch event bus to `mitt`
- adjust tooltip instantiation
- update event emissions for `mitt`
- alias Vue to compat build

## Testing
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_684eeabde90c8332b4c68f544b46c53b