### PR TITLE
Adds multiple image support to Image Viewer

### DIFF
--- a/others/customize.dashboard.dash/definitions/dashboard_v1.json
+++ b/others/customize.dashboard.dash/definitions/dashboard_v1.json
@@ -1,4361 +1,4505 @@
 {
-  "id": null,
-  "name": "Dashboard_v1",
-  "description": "@COB v6.84.0",
-  "duplicable": null,
-  "state": "enabled",
-  "fieldDefinitions": [
-    {
-      "id": null,
-      "name": "Dashboard Info",
-      "required": null,
-      "description": "$group",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Group": {}
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 0,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Solution",
-      "required": null,
-      "description": "$ref(Dashboard-Solutions,*) $instanceDescription $groupEdit",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Reference": {
-            "args": {
-              "query": "*",
-              "definition": "Dashboard-Solutions"
-            }
-          },
-          "InstanceDescription": {}
-        },
-        "extensions": {
-          "$groupEdit": {}
-        }
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [
+    "id": null,
+    "name": "Dashboard_v1",
+    "description": "@COB v6.85.0",
+    "duplicable": null,
+    "state": "enabled",
+    "fieldDefinitions": [
         {
-          "id": null,
-          "name": "Solution Sigla",
-          "required": null,
-          "description": "$auto.ref(Solution).field(Sigla)",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "AutoRefField": {
-                "args": {
-                  "source_field": "Solution",
-                  "field_name": "Sigla"
-                }
-              }
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [],
-          "order": 2,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Solution Menu",
-          "required": null,
-          "description": "$auto.ref(Solution).field(Nome Menu)",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "AutoRefField": {
-                "args": {
-                  "source_field": "Solution",
-                  "field_name": "Nome Menu"
-                }
-              }
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [],
-          "order": 3,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Solution Descrição",
-          "required": null,
-          "description": "$auto.ref(Solution).field(Descrição)",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "AutoRefField": {
-                "args": {
-                  "source_field": "Solution",
-                  "field_name": "Descrição"
-                }
-              }
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [],
-          "order": 4,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Solution Icon",
-          "required": null,
-          "description": "$auto.ref(Solution).field(icon)",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "AutoRefField": {
-                "args": {
-                  "source_field": "Solution",
-                  "field_name": "icon"
-                }
-              }
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [],
-          "order": 5,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Solution Ordem",
-          "required": null,
-          "description": "$auto.ref(Solution).field(Ordem)  $instanceDescription",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "AutoRefField": {
-                "args": {
-                  "source_field": "Solution",
-                  "field_name": "Ordem"
-                }
-              },
-              "InstanceDescription": {}
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [],
-          "order": 6,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        }
-      ],
-      "order": 1,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Name",
-      "required": null,
-      "description": "$expanded $instanceLabel",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Expanded": {
-            "args": {}
-          },
-          "InstanceLabel": {}
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 7,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Description",
-      "required": null,
-      "description": "$text $instanceDescription",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "InstanceDescription": {}
-        },
-        "extensions": {
-          "$text": {}
-        }
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 8,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Order",
-      "required": null,
-      "description": "$number $instanceDescription",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Number": {
-            "args": {}
-          },
-          "InstanceDescription": {}
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 9,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "DashboardCustomize",
-      "required": null,
-      "description": "$[Classes,Image,Width,Grid,Access,Vars,Context,DragDrop] $multiple $help[Select the defaults to change] ",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Select": {
-            "args": [
-              "Classes",
-              "Image",
-              "Width",
-              "Grid",
-              "Access",
-              "Vars",
-              "Context",
-              "DragDrop"
-            ],
-            "default": null
-          },
-          "Help": {
-            "args": [
-              "Select the defaults to change"
-            ]
-          },
-          "Multiple": {}
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [
-        {
-          "id": null,
-          "name": "DashboardClasses",
-          "required": null,
-          "description": "$text $default(h-full bg-cover bg-center overflow-auto p-3) Default: h-full bg-cover bg-center overflow-auto p-3",
-          "configuration": {
-            "description": "Default: h-full bg-cover bg-center overflow-auto p-3",
-            "keys": {
-              "Default": {
-                "args": {
-                  "value": "h-full bg-cover bg-center overflow-auto p-3"
-                }
-              }
-            },
-            "extensions": {
-              "$text": {}
-            }
-          },
-          "condition": "=Classes",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Classes"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 11,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": "h-full bg-cover bg-center overflow-auto p-3"
-        },
-        {
-          "id": null,
-          "name": "Image",
-          "required": null,
-          "description": "Default:none $image",
-          "configuration": {
-            "description": "Default:none",
-            "keys": {},
-            "extensions": {
-              "$image": {}
-            }
-          },
-          "condition": "=Image",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Image"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 12,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Width",
-          "required": null,
-          "description": "Default: max-w-6xl mx-auto ",
-          "configuration": {
-            "description": "Default: max-w-6xl mx-auto",
-            "keys": {},
-            "extensions": {}
-          },
-          "condition": "=Width",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Width"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 13,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Grid",
-          "required": null,
-          "description": "$default(grid grid-flow-row-dense md:grid-cols-12) Default: grid grid-flow-row-dense md:grid-cols-12",
-          "configuration": {
-            "description": "Default: grid grid-flow-row-dense md:grid-cols-12",
-            "keys": {
-              "Default": {
-                "args": {
-                  "value": "grid grid-flow-row-dense md:grid-cols-12"
-                }
-              }
-            },
-            "extensions": {}
-          },
-          "condition": "=Grid",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Grid"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 14,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": "grid grid-flow-row-dense md:grid-cols-12"
-        },
-        {
-          "id": null,
-          "name": "GroupAccess",
-          "required": null,
-          "description": "$instanceDescription Group allowed to access this dashboard",
-          "configuration": {
-            "description": "Group allowed to access this dashboard",
-            "keys": {
-              "InstanceDescription": {}
-            },
-            "extensions": {}
-          },
-          "condition": "=Access",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Access"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": true,
-          "fields": [],
-          "order": 15,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Context",
-          "required": null,
-          "description": "$text",
-          "configuration": {
-            "description": null,
-            "keys": {},
-            "extensions": {
-              "$text": {}
-            }
-          },
-          "condition": "=Context",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Context"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 16,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Variables",
-          "required": null,
-          "description": "$group",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "Group": {}
-            },
-            "extensions": {}
-          },
-          "condition": "=Vars",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "Vars"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": true,
-          "fields": [
-            {
-              "id": null,
-              "name": "VarName",
-              "required": null,
-              "description": null,
-              "configuration": {
+            "id": null,
+            "name": "Dashboard Info",
+            "required": null,
+            "description": "$group",
+            "configuration": {
                 "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": null,
-              "visibilityCondition": null,
-              "duplicable": false,
-              "fields": [],
-              "order": 18,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Initial Value",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": null,
-              "visibilityCondition": null,
-              "duplicable": false,
-              "fields": [],
-              "order": 19,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            }
-          ],
-          "order": 17,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "DragDropConcurrent",
-          "required": null,
-          "description": "$help[Specify a concurrent script to be executed when dropping draggable items.]",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "Help": {
-                "args": [
-                  "Specify a concurrent script to be executed when dropping draggable items."
-                ]
-              }
-            },
-            "extensions": {}
-          },
-          "condition": "=DragDrop",
-          "visibilityCondition": {
-            "type": "Equal",
-            "value": [
-              "DragDrop"
-            ],
-            "matcher": {
-              "type": "Parent"
-            }
-          },
-          "duplicable": false,
-          "fields": [],
-          "order": 20,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        }
-      ],
-      "order": 10,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "URL",
-      "required": null,
-      "description": "$link $auto.text(id).join('/recordm/index.html#/cob.custom-resource/',id,'/dash') $instanceDescription",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "AutoTextJoin": {
-            "args": [
-              "'/recordm/index.html#/cob.custom-resource/'",
-              "id",
-              "'/dash'"
-            ]
-          },
-          "InstanceDescription": {},
-          "Link": {
-            "args": {}
-          }
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 21,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Boards",
-      "required": null,
-      "description": "$group",
-      "configuration": {
-        "description": null,
-        "keys": {
-          "Group": {}
-        },
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": false,
-      "fields": [],
-      "order": 22,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    },
-    {
-      "id": null,
-      "name": "Board",
-      "required": null,
-      "description": null,
-      "configuration": {
-        "description": null,
-        "keys": {},
-        "extensions": {}
-      },
-      "condition": null,
-      "visibilityCondition": null,
-      "duplicable": true,
-      "fields": [
-        {
-          "id": null,
-          "name": "BoardCustomize",
-          "required": null,
-          "description": "$[Classes,Image,IsModal] $multiple $help[Select the defaults to change]",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "Select": {
-                "args": [
-                  "Classes",
-                  "Image",
-                  "IsModal"
-                ],
-                "default": null
-              },
-              "Help": {
-                "args": [
-                  "Select the defaults to change"
-                ]
-              },
-              "Multiple": {}
-            },
-            "extensions": {}
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": false,
-          "fields": [
-            {
-              "id": null,
-              "name": "BoardClasses",
-              "required": null,
-              "description": "$text $default(col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1)  Default:col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1",
-              "configuration": {
-                "description": "Default:col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1",
                 "keys": {
-                  "Default": {
-                    "args": {
-                      "value": "col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1"
-                    }
-                  }
+                    "Group": {}
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 0,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Solution",
+            "required": null,
+            "description": "$ref(Dashboard-Solutions,*) $instanceDescription $groupEdit",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "Reference": {
+                        "args": {
+                            "query": "*",
+                            "definition": "Dashboard-Solutions"
+                        }
+                    },
+                    "InstanceDescription": {}
                 },
                 "extensions": {
-                  "$text": {}
+                    "$groupEdit": {}
                 }
-              },
-              "condition": "=Classes",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Classes"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 25,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": "col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1"
             },
-            {
-              "id": null,
-              "name": "Image",
-              "required": null,
-              "description": "$file Default: none",
-              "configuration": {
-                "description": "Default: none",
-                "keys": {
-                  "File": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Image",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Image"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 26,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            }
-          ],
-          "order": 24,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
-        },
-        {
-          "id": null,
-          "name": "Component",
-          "required": null,
-          "description": "$[Label,Menu,Totals,Kibana,Filter,Calendar,List,Mermaid,ModalActivator,Markdown,Slides,Hierarchy,Viewer,ImageViewer,InstanceViewer] $instanceDescription $style[singleColumn]",
-          "configuration": {
-            "description": null,
-            "keys": {
-              "Select": {
-                "args": [
-                  "Label",
-                  "Menu",
-                  "Totals",
-                  "Kibana",
-                  "Filter",
-                  "Calendar",
-                  "List",
-                  "Mermaid",
-                  "ModalActivator",
-                  "Markdown",
-                  "Slides",
-                  "Hierarchy",
-                  "Viewer",
-                  "ImageViewer",
-                  "InstanceViewer"
-                ],
-                "default": null
-              },
-              "InstanceDescription": {}
-            },
-            "extensions": {
-              "$style": {
-                "args": [
-                  "singleColumn"
-                ]
-              }
-            }
-          },
-          "condition": null,
-          "visibilityCondition": null,
-          "duplicable": true,
-          "fields": [
-            {
-              "id": null,
-              "name": "LabelCustomize",
-              "required": null,
-              "description": "$[Classes,Image] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "Image"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Label",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Label"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [
                 {
-                  "id": null,
-                  "name": "LabelClasses",
-                  "required": null,
-                  "description": "$text $default(text-center font-bold pb-2) Default: text-center font-bold pb-2 ",
-                  "configuration": {
-                    "description": "Default: text-center font-bold pb-2",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-center font-bold pb-2"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 29,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-center font-bold pb-2"
-                },
-                {
-                  "id": null,
-                  "name": "Image",
-                  "required": null,
-                  "description": "$file Default: none",
-                  "configuration": {
-                    "description": "Default: none",
-                    "keys": {
-                      "File": {}
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=Image",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Image"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 30,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 28,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Label",
-              "required": null,
-              "description": "$text",
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {
-                  "$text": {}
-                }
-              },
-              "condition": "=Label",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Label"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 31,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "MenuCustomize",
-              "required": null,
-              "description": "$[Classes] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Menu",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Menu"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "MenuClasses",
-                  "required": null,
-                  "description": "$text $default(flex flex-col gap-y-2) Default: flex flex-col gap-y-2",
-                  "configuration": {
-                    "description": "Default: flex flex-col gap-y-2",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "flex flex-col gap-y-2"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 33,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "flex flex-col gap-y-2"
-                }
-              ],
-              "order": 32,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Text",
-              "required": null,
-              "description": "$text",
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {
-                  "$text": {}
-                }
-              },
-              "condition": "=Menu",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Menu"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": true,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "TextCustomize",
-                  "required": null,
-                  "description": "$[Classes,Icon,Attention,Visibility,Filter] $multiple $help[Select the defaults to change]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "Classes",
-                          "Icon",
-                          "Attention",
-                          "Visibility",
-                          "Filter"
-                        ],
-                        "default": null
-                      },
-                      "Help": {
-                        "args": [
-                          "Select the defaults to change"
-                        ]
-                      },
-                      "Multiple": {}
-                    },
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [
-                    {
-                      "id": null,
-                      "name": "TextClasses",
-                      "required": null,
-                      "description": "$text $default(rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white) Default: rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white",
-                      "configuration": {
-                        "description": "Default: rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white",
-                        "keys": {
-                          "Default": {
-                            "args": {
-                              "value": "rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white"
-                            }
-                          }
-                        },
-                        "extensions": {
-                          "$text": {}
-                        }
-                      },
-                      "condition": "=Classes",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Classes"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 36,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": "rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white"
-                    },
-                    {
-                      "id": null,
-                      "name": "Icon",
-                      "required": null,
-                      "description": "Default: none Example: fa-solid fa-circle-chevron-left",
-                      "configuration": {
-                        "description": "Default: none Example: fa-solid fa-circle-chevron-left",
-                        "keys": {},
-                        "extensions": {}
-                      },
-                      "condition": "=Icon",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Icon"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 37,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    },
-                    {
-                      "id": null,
-                      "name": "TextAttention",
-                      "required": null,
-                      "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
-                      "configuration": {
-                        "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
-                        "keys": {},
-                        "extensions": {}
-                      },
-                      "condition": "=Attention",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Attention"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 38,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    }
-                  ],
-                  "order": 35,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "Link",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "TextCustomize!Filter",
-                  "visibilityCondition": {
-                    "type": "NotEqual",
-                    "value": [
-                      "Filter"
-                    ],
-                    "matcher": {
-                      "type": "Name",
-                      "name": "TextCustomize"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 39,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "FilterVarName",
-                  "required": "mandatory",
-                  "description": "The filter variable name",
-                  "configuration": {
-                    "description": "The filter variable name",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "TextCustomize=Filter",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Filter"
-                    ],
-                    "matcher": {
-                      "type": "Name",
-                      "name": "TextCustomize"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 40,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "FilterValue",
-                  "required": null,
-                  "description": "The value of the filter $text",
-                  "configuration": {
-                    "description": "The value of the filter",
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "TextCustomize=Filter",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Filter"
-                    ],
-                    "matcher": {
-                      "type": "Name",
-                      "name": "TextCustomize"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 41,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 34,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "TotalsCustomize",
-              "required": null,
-              "description": "$[Classes,InputVar] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "InputVar"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Totals",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Totals"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "TotalsClasses",
-                  "required": null,
-                  "description": "$text $default(w-full table-auto) Default: w-full table-auto",
-                  "configuration": {
-                    "description": "Default: w-full table-auto",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "w-full table-auto"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 43,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "w-full table-auto"
-                },
-                {
-                  "id": null,
-                  "name": "InputVarTotals",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=InputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "InputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": true,
-                  "fields": [],
-                  "order": 44,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 42,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Line",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Totals",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Totals"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": true,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "LineCustomize",
-                  "required": null,
-                  "description": "$[LineClasses,TitleClasses,Behaviour] $multiple $help[Select the defaults to change]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "LineClasses",
-                          "TitleClasses",
-                          "Behaviour"
-                        ],
-                        "default": null
-                      },
-                      "Help": {
-                        "args": [
-                          "Select the defaults to change"
-                        ]
-                      },
-                      "Multiple": {}
-                    },
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [
-                    {
-                      "id": null,
-                      "name": "LineClasses",
-                      "required": null,
-                      "description": "$text $default(text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300) Default: text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300",
-                      "configuration": {
-                        "description": "Default: text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300",
-                        "keys": {
-                          "Default": {
-                            "args": {
-                              "value": "text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300"
-                            }
-                          }
-                        },
-                        "extensions": {
-                          "$text": {}
-                        }
-                      },
-                      "condition": "=LineClasses",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "LineClasses"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 47,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": "text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300"
-                    },
-                    {
-                      "id": null,
-                      "name": "TitleClasses",
-                      "required": null,
-                      "description": "$text $default(text-left text-stone-600 p-1) Default: text-left text-stone-600 p-1",
-                      "configuration": {
-                        "description": "Default: text-left text-stone-600 p-1",
-                        "keys": {
-                          "Default": {
-                            "args": {
-                              "value": "text-left text-stone-600 p-1"
-                            }
-                          }
-                        },
-                        "extensions": {
-                          "$text": {}
-                        }
-                      },
-                      "condition": "=TitleClasses",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "TitleClasses"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 48,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": "text-left text-stone-600 p-1"
-                    }
-                  ],
-                  "order": 46,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "Value",
-                  "required": null,
-                  "description": "$[*Label,definitionCount,domainCount,fieldSum,fieldAverage,fieldWeightedAverage,dmEquipmentCount,link] ",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "Label",
-                          "definitionCount",
-                          "domainCount",
-                          "fieldSum",
-                          "fieldAverage",
-                          "fieldWeightedAverage",
-                          "dmEquipmentCount",
-                          "link"
-                        ],
-                        "default": "Label"
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": true,
-                  "fields": [
-                    {
-                      "id": null,
-                      "name": "ValueCustomize",
-                      "required": null,
-                      "description": "$[Classes,View,Attention,AttentionClasses,Unit] $multiple $help[Select the defaults to change]",
-                      "configuration": {
+                    "id": null,
+                    "name": "Solution Sigla",
+                    "required": null,
+                    "description": "$auto.ref(Solution).field(Sigla)",
+                    "configuration": {
                         "description": null,
                         "keys": {
-                          "Select": {
-                            "args": [
-                              "Classes",
-                              "View",
-                              "Attention",
-                              "AttentionClasses",
-                              "Unit"
-                            ],
-                            "default": null
-                          },
-                          "Help": {
-                            "args": [
-                              "Select the defaults to change"
-                            ]
-                          },
-                          "Multiple": {}
+                            "AutoRefField": {
+                                "args": {
+                                    "source_field": "Solution",
+                                    "field_name": "Sigla"
+                                }
+                            }
                         },
                         "extensions": {}
-                      },
-                      "condition": null,
-                      "visibilityCondition": null,
-                      "duplicable": false,
-                      "fields": [
-                        {
-                          "id": null,
-                          "name": "ValueClasses",
-                          "required": null,
-                          "description": "$text $default(Default Info text-sm text-stone-800) Default: Default Info text-sm text-stone-800  <=>  border-sky-500   bg-sky-50   inline-block m-1  whitespace-nowrap  font-mono font-semibold  px-2 py-1  border rounded-md  ring-sky-600 ring-offset-0 hover:ring-1 ring-stone-300  text-sm text-stone-800",
-                          "configuration": {
-                            "description": "Default: Default Info text-sm text-stone-800  <=>  border-sky-500   bg-sky-50   inline-block m-1  whitespace-nowrap  font-mono font-semibold  px-2 py-1  border rounded-md  ring-sky-600 ring-offset-0 hover:ring-1 ring-stone-300  text-sm text-stone-800",
-                            "keys": {
-                              "Default": {
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 2,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Solution Menu",
+                    "required": null,
+                    "description": "$auto.ref(Solution).field(Nome Menu)",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "AutoRefField": {
                                 "args": {
-                                  "value": "Default Info text-sm text-stone-800"
+                                    "source_field": "Solution",
+                                    "field_name": "Nome Menu"
                                 }
-                              }
-                            },
-                            "extensions": {
-                              "$text": {}
                             }
-                          },
-                          "condition": "=Classes",
-                          "visibilityCondition": {
-                            "type": "Equal",
-                            "value": [
-                              "Classes"
-                            ],
-                            "matcher": {
-                              "type": "Parent"
-                            }
-                          },
-                          "duplicable": false,
-                          "fields": [],
-                          "order": 51,
-                          "restricted": false,
-                          "rootField": false,
-                          "defaultValue": "Default Info text-sm text-stone-800"
                         },
-                        {
-                          "id": null,
-                          "name": "View",
-                          "required": null,
-                          "description": "Default: none",
-                          "configuration": {
-                            "description": "Default: none",
-                            "keys": {},
-                            "extensions": {}
-                          },
-                          "condition": "=View",
-                          "visibilityCondition": {
-                            "type": "Equal",
-                            "value": [
-                              "View"
-                            ],
-                            "matcher": {
-                              "type": "Parent"
-                            }
-                          },
-                          "duplicable": false,
-                          "fields": [],
-                          "order": 52,
-                          "restricted": false,
-                          "rootField": false,
-                          "defaultValue": null
-                        },
-                        {
-                          "id": null,
-                          "name": "ValueAttention",
-                          "required": null,
-                          "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
-                          "configuration": {
-                            "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
-                            "keys": {},
-                            "extensions": {}
-                          },
-                          "condition": "=Attention",
-                          "visibilityCondition": {
-                            "type": "Equal",
-                            "value": [
-                              "Attention"
-                            ],
-                            "matcher": {
-                              "type": "Parent"
-                            }
-                          },
-                          "duplicable": false,
-                          "fields": [],
-                          "order": 53,
-                          "restricted": false,
-                          "rootField": false,
-                          "defaultValue": null
-                        },
-                        {
-                          "id": null,
-                          "name": "ValueAttentionClasses",
-                          "required": null,
-                          "description": "$text $default(fa-solid fa-circle pr-1 animate-pulse text-lg align-middle) Default: fa-solid fa-circle pr-1 animate-pulse text-lg align-middle",
-                          "configuration": {
-                            "description": "Default: fa-solid fa-circle pr-1 animate-pulse text-lg align-middle",
-                            "keys": {
-                              "Default": {
+                        "extensions": {}
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 3,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Solution Descrição",
+                    "required": null,
+                    "description": "$auto.ref(Solution).field(Descrição)",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "AutoRefField": {
                                 "args": {
-                                  "value": "fa-solid fa-circle pr-1 animate-pulse text-lg align-middle"
+                                    "source_field": "Solution",
+                                    "field_name": "Descrição"
                                 }
-                              }
-                            },
-                            "extensions": {
-                              "$text": {}
                             }
-                          },
-                          "condition": "=AttentionClasses",
-                          "visibilityCondition": {
-                            "type": "Equal",
-                            "value": [
-                              "AttentionClasses"
-                            ],
-                            "matcher": {
-                              "type": "Parent"
-                            }
-                          },
-                          "duplicable": false,
-                          "fields": [],
-                          "order": 54,
-                          "restricted": false,
-                          "rootField": false,
-                          "defaultValue": "fa-solid fa-circle pr-1 animate-pulse text-lg align-middle"
                         },
+                        "extensions": {}
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 4,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Solution Icon",
+                    "required": null,
+                    "description": "$auto.ref(Solution).field(icon)",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "AutoRefField": {
+                                "args": {
+                                    "source_field": "Solution",
+                                    "field_name": "icon"
+                                }
+                            }
+                        },
+                        "extensions": {}
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 5,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Solution Ordem",
+                    "required": null,
+                    "description": "$auto.ref(Solution).field(Ordem)  $instanceDescription",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "AutoRefField": {
+                                "args": {
+                                    "source_field": "Solution",
+                                    "field_name": "Ordem"
+                                }
+                            },
+                            "InstanceDescription": {}
+                        },
+                        "extensions": {}
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 6,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                }
+            ],
+            "order": 1,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Name",
+            "required": null,
+            "description": "$expanded $instanceLabel",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "Expanded": {
+                        "args": {}
+                    },
+                    "InstanceLabel": {}
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 7,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Description",
+            "required": null,
+            "description": "$text $instanceDescription",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "InstanceDescription": {}
+                },
+                "extensions": {
+                    "$text": {}
+                }
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 8,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Order",
+            "required": null,
+            "description": "$number $instanceDescription",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "Number": {
+                        "args": {}
+                    },
+                    "InstanceDescription": {}
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 9,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "DashboardCustomize",
+            "required": null,
+            "description": "$[Classes,Image,Width,Grid,Access,Vars,Context,DragDrop] $multiple $help[Select the defaults to change] ",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "Multiple": {},
+                    "Help": {
+                        "args": [
+                            "Select the defaults to change"
+                        ]
+                    },
+                    "Select": {
+                        "args": [
+                            "Classes",
+                            "Image",
+                            "Width",
+                            "Grid",
+                            "Access",
+                            "Vars",
+                            "Context",
+                            "DragDrop"
+                        ],
+                        "default": null
+                    }
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [
+                {
+                    "id": null,
+                    "name": "DashboardClasses",
+                    "required": null,
+                    "description": "$text $default(h-full bg-cover bg-center overflow-auto p-3) Default: h-full bg-cover bg-center overflow-auto p-3",
+                    "configuration": {
+                        "description": "Default: h-full bg-cover bg-center overflow-auto p-3",
+                        "keys": {
+                            "Default": {
+                                "args": {
+                                    "value": "h-full bg-cover bg-center overflow-auto p-3"
+                                }
+                            }
+                        },
+                        "extensions": {
+                            "$text": {}
+                        }
+                    },
+                    "condition": "=Classes",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Classes"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 11,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": "h-full bg-cover bg-center overflow-auto p-3"
+                },
+                {
+                    "id": null,
+                    "name": "Image",
+                    "required": null,
+                    "description": "Default:none $image",
+                    "configuration": {
+                        "description": "Default:none",
+                        "keys": {},
+                        "extensions": {
+                            "$image": {}
+                        }
+                    },
+                    "condition": "=Image",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Image"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 12,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Width",
+                    "required": null,
+                    "description": "Default: max-w-6xl mx-auto ",
+                    "configuration": {
+                        "description": "Default: max-w-6xl mx-auto",
+                        "keys": {},
+                        "extensions": {}
+                    },
+                    "condition": "=Width",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Width"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 13,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Grid",
+                    "required": null,
+                    "description": "$default(grid grid-flow-row-dense md:grid-cols-12) Default: grid grid-flow-row-dense md:grid-cols-12",
+                    "configuration": {
+                        "description": "Default: grid grid-flow-row-dense md:grid-cols-12",
+                        "keys": {
+                            "Default": {
+                                "args": {
+                                    "value": "grid grid-flow-row-dense md:grid-cols-12"
+                                }
+                            }
+                        },
+                        "extensions": {}
+                    },
+                    "condition": "=Grid",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Grid"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 14,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": "grid grid-flow-row-dense md:grid-cols-12"
+                },
+                {
+                    "id": null,
+                    "name": "GroupAccess",
+                    "required": null,
+                    "description": "$instanceDescription Group allowed to access this dashboard",
+                    "configuration": {
+                        "description": "Group allowed to access this dashboard",
+                        "keys": {
+                            "InstanceDescription": {}
+                        },
+                        "extensions": {}
+                    },
+                    "condition": "=Access",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Access"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": true,
+                    "fields": [],
+                    "order": 15,
+                    "duplicablePath": true,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Context",
+                    "required": null,
+                    "description": "$text",
+                    "configuration": {
+                        "description": null,
+                        "keys": {},
+                        "extensions": {
+                            "$text": {}
+                        }
+                    },
+                    "condition": "=Context",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Context"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 16,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "Variables",
+                    "required": null,
+                    "description": "$group",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "Group": {}
+                        },
+                        "extensions": {}
+                    },
+                    "condition": "=Vars",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "Vars"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": true,
+                    "fields": [
                         {
-                          "id": null,
-                          "name": "Unit",
-                          "required": null,
-                          "description": null,
-                          "configuration": {
+                            "id": null,
+                            "name": "VarName",
+                            "required": null,
                             "description": null,
-                            "keys": {},
-                            "extensions": {}
-                          },
-                          "condition": "=Unit",
-                          "visibilityCondition": {
-                            "type": "Equal",
-                            "value": [
-                              "Unit"
-                            ],
-                            "matcher": {
-                              "type": "Parent"
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": null,
+                            "visibilityCondition": null,
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 18,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Initial Value",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": null,
+                            "visibilityCondition": null,
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 19,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        }
+                    ],
+                    "order": 17,
+                    "duplicablePath": true,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                },
+                {
+                    "id": null,
+                    "name": "DragDropConcurrent",
+                    "required": null,
+                    "description": "$help[Specify a concurrent script to be executed when dropping draggable items.]",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "Help": {
+                                "args": [
+                                    "Specify a concurrent script to be executed when dropping draggable items."
+                                ]
                             }
-                          },
-                          "duplicable": false,
-                          "fields": [],
-                          "order": 55,
-                          "restricted": false,
-                          "rootField": false,
-                          "defaultValue": null
-                        }
-                      ],
-                      "order": 50,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    },
-                    {
-                      "id": null,
-                      "name": "Arg",
-                      "required": null,
-                      "description": null,
-                      "configuration": {
-                        "description": null,
-                        "keys": {},
+                        },
                         "extensions": {}
-                      },
-                      "condition": null,
-                      "visibilityCondition": null,
-                      "duplicable": true,
-                      "fields": [],
-                      "order": 56,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
+                    },
+                    "condition": "=DragDrop",
+                    "visibilityCondition": {
+                        "type": "Equal",
+                        "value": [
+                            "DragDrop"
+                        ],
+                        "matcher": {
+                            "type": "Parent"
+                        }
+                    },
+                    "duplicable": false,
+                    "fields": [],
+                    "order": 20,
+                    "duplicablePath": false,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
+                }
+            ],
+            "order": 10,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "URL",
+            "required": null,
+            "description": "$link $auto.text(id).join('/recordm/index.html#/cob.custom-resource/',id,'/dash') $instanceDescription",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "AutoTextJoin": {
+                        "args": [
+                            "'/recordm/index.html#/cob.custom-resource/'",
+                            "id",
+                            "'/dash'"
+                        ]
+                    },
+                    "InstanceDescription": {},
+                    "Link": {
+                        "args": {}
                     }
-                  ],
-                  "order": 49,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "Label"
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 21,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Boards",
+            "required": null,
+            "description": "$group",
+            "configuration": {
+                "description": null,
+                "keys": {
+                    "Group": {}
+                },
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": false,
+            "fields": [],
+            "order": 22,
+            "duplicablePath": false,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
+        },
+        {
+            "id": null,
+            "name": "Board",
+            "required": null,
+            "description": null,
+            "configuration": {
+                "description": null,
+                "keys": {},
+                "extensions": {}
+            },
+            "condition": null,
+            "visibilityCondition": null,
+            "duplicable": true,
+            "fields": [
+                {
+                    "id": null,
+                    "name": "BoardCustomize",
+                    "required": null,
+                    "description": "$[Classes,Image,IsModal] $multiple $help[Select the defaults to change]",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "Multiple": {},
+                            "Help": {
+                                "args": [
+                                    "Select the defaults to change"
+                                ]
+                            },
+                            "Select": {
+                                "args": [
+                                    "Classes",
+                                    "Image",
+                                    "IsModal"
+                                ],
+                                "default": null
+                            }
+                        },
+                        "extensions": {}
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": false,
+                    "fields": [
+                        {
+                            "id": null,
+                            "name": "BoardClasses",
+                            "required": null,
+                            "description": "$text $default(col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1)  Default:col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1",
+                            "configuration": {
+                                "description": "Default:col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1",
+                                "keys": {
+                                    "Default": {
+                                        "args": {
+                                            "value": "col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1"
+                                        }
+                                    }
+                                },
+                                "extensions": {
+                                    "$text": {}
+                                }
+                            },
+                            "condition": "=Classes",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Classes"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 25,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": "col-span-12 md:col-span-4 rounded-md border border-gray-300 bg-white bg-opacity-70 p-4 m-1"
+                        },
+                        {
+                            "id": null,
+                            "name": "Image",
+                            "required": null,
+                            "description": "$file Default: none",
+                            "configuration": {
+                                "description": "Default: none",
+                                "keys": {
+                                    "File": {}
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Image",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Image"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 26,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        }
+                    ],
+                    "order": 24,
+                    "duplicablePath": true,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
                 },
                 {
-                  "id": null,
-                  "name": "LineBehaviour",
-                  "required": null,
-                  "description": "$[*Listing,Filter,Link] $help[Select how you want this component to behave. <br/> Listing: Default behavior <br/> Link: Every line uses a custom link and redirects upon clicking. <br/> Filter: allows the specification of a var and its value to be used across components in the dashboard.]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "Listing",
-                          "Filter",
-                          "Link"
-                        ],
-                        "default": "Listing"
-                      },
-                      "Help": {
-                        "args": [
-                          "Select how you want this component to behave. <br/> Listing: Default behavior <br/> Link: Every line uses a custom link and redirects upon clicking. <br/> Filter: allows the specification of a var and its value to be used across components in the dashboard."
-                        ]
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "LineCustomize=Behaviour",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Behaviour"
-                    ],
-                    "matcher": {
-                      "type": "Name",
-                      "name": "LineCustomize"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [
-                    {
-                      "id": null,
-                      "name": "FilterTotalValue",
-                      "required": null,
-                      "description": "The value of the filter $text",
-                      "configuration": {
-                        "description": "The value of the filter",
-                        "keys": {},
+                    "id": null,
+                    "name": "Component",
+                    "required": null,
+                    "description": "$[Label,Menu,Totals,Kibana,Filter,Calendar,List,Mermaid,ModalActivator,Markdown,Slides,Hierarchy,Viewer,ImageViewer,InstanceViewer] $instanceDescription $style[singleColumn]",
+                    "configuration": {
+                        "description": null,
+                        "keys": {
+                            "Select": {
+                                "args": [
+                                    "Label",
+                                    "Menu",
+                                    "Totals",
+                                    "Kibana",
+                                    "Filter",
+                                    "Calendar",
+                                    "List",
+                                    "Mermaid",
+                                    "ModalActivator",
+                                    "Markdown",
+                                    "Slides",
+                                    "Hierarchy",
+                                    "Viewer",
+                                    "ImageViewer",
+                                    "InstanceViewer"
+                                ],
+                                "default": null
+                            },
+                            "InstanceDescription": {}
+                        },
                         "extensions": {
-                          "$text": {}
+                            "$style": {
+                                "args": [
+                                    "singleColumn"
+                                ]
+                            }
                         }
-                      },
-                      "condition": "=Filter",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Filter"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
+                    },
+                    "condition": null,
+                    "visibilityCondition": null,
+                    "duplicable": true,
+                    "fields": [
+                        {
+                            "id": null,
+                            "name": "LabelCustomize",
+                            "required": null,
+                            "description": "$[Classes,Image] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "Image"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Label",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Label"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "LabelClasses",
+                                    "required": null,
+                                    "description": "$text $default(text-center font-bold pb-2) Default: text-center font-bold pb-2 ",
+                                    "configuration": {
+                                        "description": "Default: text-center font-bold pb-2",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-center font-bold pb-2"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 29,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-center font-bold pb-2"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Image",
+                                    "required": null,
+                                    "description": "$file Default: none",
+                                    "configuration": {
+                                        "description": "Default: none",
+                                        "keys": {
+                                            "File": {}
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Image",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Image"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 30,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 28,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Label",
+                            "required": null,
+                            "description": "$text",
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {
+                                    "$text": {}
+                                }
+                            },
+                            "condition": "=Label",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Label"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 31,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "MenuCustomize",
+                            "required": null,
+                            "description": "$[Classes] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Menu",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Menu"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "MenuClasses",
+                                    "required": null,
+                                    "description": "$text $default(flex flex-col gap-y-2) Default: flex flex-col gap-y-2",
+                                    "configuration": {
+                                        "description": "Default: flex flex-col gap-y-2",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "flex flex-col gap-y-2"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 33,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "flex flex-col gap-y-2"
+                                }
+                            ],
+                            "order": 32,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Text",
+                            "required": null,
+                            "description": "$text",
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {
+                                    "$text": {}
+                                }
+                            },
+                            "condition": "=Menu",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Menu"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": true,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "TextCustomize",
+                                    "required": null,
+                                    "description": "$[Classes,Icon,Attention,Visibility,Filter] $multiple $help[Select the defaults to change]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Multiple": {},
+                                            "Help": {
+                                                "args": [
+                                                    "Select the defaults to change"
+                                                ]
+                                            },
+                                            "Select": {
+                                                "args": [
+                                                    "Classes",
+                                                    "Icon",
+                                                    "Attention",
+                                                    "Visibility",
+                                                    "Filter"
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [
+                                        {
+                                            "id": null,
+                                            "name": "TextClasses",
+                                            "required": null,
+                                            "description": "$text $default(rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white) Default: rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white",
+                                            "configuration": {
+                                                "description": "Default: rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white",
+                                                "keys": {
+                                                    "Default": {
+                                                        "args": {
+                                                            "value": "rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white"
+                                                        }
+                                                    }
+                                                },
+                                                "extensions": {
+                                                    "$text": {}
+                                                }
+                                            },
+                                            "condition": "=Classes",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Classes"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 36,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": "rounded-md border border-gray-300 border-l-2 border-l-sky-600 shadow-sm hover:bg-sky-800 hover:text-white p-2 bg-white"
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "Icon",
+                                            "required": null,
+                                            "description": "Default: none Example: fa-solid fa-circle-chevron-left",
+                                            "configuration": {
+                                                "description": "Default: none Example: fa-solid fa-circle-chevron-left",
+                                                "keys": {},
+                                                "extensions": {}
+                                            },
+                                            "condition": "=Icon",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Icon"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 37,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "TextAttention",
+                                            "required": null,
+                                            "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
+                                            "configuration": {
+                                                "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
+                                                "keys": {},
+                                                "extensions": {}
+                                            },
+                                            "condition": "=Attention",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Attention"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 38,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        }
+                                    ],
+                                    "order": 35,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Link",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "TextCustomize!Filter",
+                                    "visibilityCondition": {
+                                        "type": "NotEqual",
+                                        "value": [
+                                            "Filter"
+                                        ],
+                                        "matcher": {
+                                            "type": "Name",
+                                            "name": "TextCustomize"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 39,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "FilterVarName",
+                                    "required": "mandatory",
+                                    "description": "The filter variable name",
+                                    "configuration": {
+                                        "description": "The filter variable name",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "TextCustomize=Filter",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Filter"
+                                        ],
+                                        "matcher": {
+                                            "type": "Name",
+                                            "name": "TextCustomize"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 40,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "FilterValue",
+                                    "required": null,
+                                    "description": "The value of the filter $text",
+                                    "configuration": {
+                                        "description": "The value of the filter",
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "TextCustomize=Filter",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Filter"
+                                        ],
+                                        "matcher": {
+                                            "type": "Name",
+                                            "name": "TextCustomize"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 41,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 34,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "TotalsCustomize",
+                            "required": null,
+                            "description": "$[Classes,InputVar] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "InputVar"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Totals",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Totals"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "TotalsClasses",
+                                    "required": null,
+                                    "description": "$text $default(w-full table-auto) Default: w-full table-auto",
+                                    "configuration": {
+                                        "description": "Default: w-full table-auto",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "w-full table-auto"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 43,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "w-full table-auto"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InputVarTotals",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=InputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "InputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": true,
+                                    "fields": [],
+                                    "order": 44,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 42,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Line",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Totals",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Totals"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": true,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "LineCustomize",
+                                    "required": null,
+                                    "description": "$[LineClasses,TitleClasses,Behaviour] $multiple $help[Select the defaults to change]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Multiple": {},
+                                            "Help": {
+                                                "args": [
+                                                    "Select the defaults to change"
+                                                ]
+                                            },
+                                            "Select": {
+                                                "args": [
+                                                    "LineClasses",
+                                                    "TitleClasses",
+                                                    "Behaviour"
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [
+                                        {
+                                            "id": null,
+                                            "name": "LineClasses",
+                                            "required": null,
+                                            "description": "$text $default(text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300) Default: text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300",
+                                            "configuration": {
+                                                "description": "Default: text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300",
+                                                "keys": {
+                                                    "Default": {
+                                                        "args": {
+                                                            "value": "text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300"
+                                                        }
+                                                    }
+                                                },
+                                                "extensions": {
+                                                    "$text": {}
+                                                }
+                                            },
+                                            "condition": "=LineClasses",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "LineClasses"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 47,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": "text-right transition ease-in-out rounded ring-offset-0 hover:ring-1 ring-stone-300"
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "TitleClasses",
+                                            "required": null,
+                                            "description": "$text $default(text-left text-stone-600 p-1) Default: text-left text-stone-600 p-1",
+                                            "configuration": {
+                                                "description": "Default: text-left text-stone-600 p-1",
+                                                "keys": {
+                                                    "Default": {
+                                                        "args": {
+                                                            "value": "text-left text-stone-600 p-1"
+                                                        }
+                                                    }
+                                                },
+                                                "extensions": {
+                                                    "$text": {}
+                                                }
+                                            },
+                                            "condition": "=TitleClasses",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "TitleClasses"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 48,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": "text-left text-stone-600 p-1"
+                                        }
+                                    ],
+                                    "order": 46,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Value",
+                                    "required": null,
+                                    "description": "$[*Label,definitionCount,domainCount,fieldSum,fieldAverage,fieldWeightedAverage,dmEquipmentCount,link] ",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Select": {
+                                                "args": [
+                                                    "Label",
+                                                    "definitionCount",
+                                                    "domainCount",
+                                                    "fieldSum",
+                                                    "fieldAverage",
+                                                    "fieldWeightedAverage",
+                                                    "dmEquipmentCount",
+                                                    "link"
+                                                ],
+                                                "default": "Label"
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": true,
+                                    "fields": [
+                                        {
+                                            "id": null,
+                                            "name": "ValueCustomize",
+                                            "required": null,
+                                            "description": "$[Classes,View,Attention,AttentionClasses,Unit] $multiple $help[Select the defaults to change]",
+                                            "configuration": {
+                                                "description": null,
+                                                "keys": {
+                                                    "Multiple": {},
+                                                    "Help": {
+                                                        "args": [
+                                                            "Select the defaults to change"
+                                                        ]
+                                                    },
+                                                    "Select": {
+                                                        "args": [
+                                                            "Classes",
+                                                            "View",
+                                                            "Attention",
+                                                            "AttentionClasses",
+                                                            "Unit"
+                                                        ],
+                                                        "default": null
+                                                    }
+                                                },
+                                                "extensions": {}
+                                            },
+                                            "condition": null,
+                                            "visibilityCondition": null,
+                                            "duplicable": false,
+                                            "fields": [
+                                                {
+                                                    "id": null,
+                                                    "name": "ValueClasses",
+                                                    "required": null,
+                                                    "description": "$text $default(Default Info text-sm text-stone-800) Default: Default Info text-sm text-stone-800  <=>  border-sky-500   bg-sky-50   inline-block m-1  whitespace-nowrap  font-mono font-semibold  px-2 py-1  border rounded-md  ring-sky-600 ring-offset-0 hover:ring-1 ring-stone-300  text-sm text-stone-800",
+                                                    "configuration": {
+                                                        "description": "Default: Default Info text-sm text-stone-800  <=>  border-sky-500   bg-sky-50   inline-block m-1  whitespace-nowrap  font-mono font-semibold  px-2 py-1  border rounded-md  ring-sky-600 ring-offset-0 hover:ring-1 ring-stone-300  text-sm text-stone-800",
+                                                        "keys": {
+                                                            "Default": {
+                                                                "args": {
+                                                                    "value": "Default Info text-sm text-stone-800"
+                                                                }
+                                                            }
+                                                        },
+                                                        "extensions": {
+                                                            "$text": {}
+                                                        }
+                                                    },
+                                                    "condition": "=Classes",
+                                                    "visibilityCondition": {
+                                                        "type": "Equal",
+                                                        "value": [
+                                                            "Classes"
+                                                        ],
+                                                        "matcher": {
+                                                            "type": "Parent"
+                                                        }
+                                                    },
+                                                    "duplicable": false,
+                                                    "fields": [],
+                                                    "order": 51,
+                                                    "duplicablePath": true,
+                                                    "restricted": false,
+                                                    "rootField": false,
+                                                    "defaultValue": "Default Info text-sm text-stone-800"
+                                                },
+                                                {
+                                                    "id": null,
+                                                    "name": "View",
+                                                    "required": null,
+                                                    "description": "Default: none",
+                                                    "configuration": {
+                                                        "description": "Default: none",
+                                                        "keys": {},
+                                                        "extensions": {}
+                                                    },
+                                                    "condition": "=View",
+                                                    "visibilityCondition": {
+                                                        "type": "Equal",
+                                                        "value": [
+                                                            "View"
+                                                        ],
+                                                        "matcher": {
+                                                            "type": "Parent"
+                                                        }
+                                                    },
+                                                    "duplicable": false,
+                                                    "fields": [],
+                                                    "order": 52,
+                                                    "duplicablePath": true,
+                                                    "restricted": false,
+                                                    "rootField": false,
+                                                    "defaultValue": null
+                                                },
+                                                {
+                                                    "id": null,
+                                                    "name": "ValueAttention",
+                                                    "required": null,
+                                                    "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
+                                                    "configuration": {
+                                                        "description": "Crisis:<=-5, ActionableBad:-4 .. -1, No action Required:0, ActionableGood:1..4,Extraordinary:>=5",
+                                                        "keys": {},
+                                                        "extensions": {}
+                                                    },
+                                                    "condition": "=Attention",
+                                                    "visibilityCondition": {
+                                                        "type": "Equal",
+                                                        "value": [
+                                                            "Attention"
+                                                        ],
+                                                        "matcher": {
+                                                            "type": "Parent"
+                                                        }
+                                                    },
+                                                    "duplicable": false,
+                                                    "fields": [],
+                                                    "order": 53,
+                                                    "duplicablePath": true,
+                                                    "restricted": false,
+                                                    "rootField": false,
+                                                    "defaultValue": null
+                                                },
+                                                {
+                                                    "id": null,
+                                                    "name": "ValueAttentionClasses",
+                                                    "required": null,
+                                                    "description": "$text $default(fa-solid fa-circle pr-1 animate-pulse text-lg align-middle) Default: fa-solid fa-circle pr-1 animate-pulse text-lg align-middle",
+                                                    "configuration": {
+                                                        "description": "Default: fa-solid fa-circle pr-1 animate-pulse text-lg align-middle",
+                                                        "keys": {
+                                                            "Default": {
+                                                                "args": {
+                                                                    "value": "fa-solid fa-circle pr-1 animate-pulse text-lg align-middle"
+                                                                }
+                                                            }
+                                                        },
+                                                        "extensions": {
+                                                            "$text": {}
+                                                        }
+                                                    },
+                                                    "condition": "=AttentionClasses",
+                                                    "visibilityCondition": {
+                                                        "type": "Equal",
+                                                        "value": [
+                                                            "AttentionClasses"
+                                                        ],
+                                                        "matcher": {
+                                                            "type": "Parent"
+                                                        }
+                                                    },
+                                                    "duplicable": false,
+                                                    "fields": [],
+                                                    "order": 54,
+                                                    "duplicablePath": true,
+                                                    "restricted": false,
+                                                    "rootField": false,
+                                                    "defaultValue": "fa-solid fa-circle pr-1 animate-pulse text-lg align-middle"
+                                                },
+                                                {
+                                                    "id": null,
+                                                    "name": "Unit",
+                                                    "required": null,
+                                                    "description": null,
+                                                    "configuration": {
+                                                        "description": null,
+                                                        "keys": {},
+                                                        "extensions": {}
+                                                    },
+                                                    "condition": "=Unit",
+                                                    "visibilityCondition": {
+                                                        "type": "Equal",
+                                                        "value": [
+                                                            "Unit"
+                                                        ],
+                                                        "matcher": {
+                                                            "type": "Parent"
+                                                        }
+                                                    },
+                                                    "duplicable": false,
+                                                    "fields": [],
+                                                    "order": 55,
+                                                    "duplicablePath": true,
+                                                    "restricted": false,
+                                                    "rootField": false,
+                                                    "defaultValue": null
+                                                }
+                                            ],
+                                            "order": 50,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "Arg",
+                                            "required": null,
+                                            "description": null,
+                                            "configuration": {
+                                                "description": null,
+                                                "keys": {},
+                                                "extensions": {}
+                                            },
+                                            "condition": null,
+                                            "visibilityCondition": null,
+                                            "duplicable": true,
+                                            "fields": [],
+                                            "order": 56,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        }
+                                    ],
+                                    "order": 49,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "Label"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "LineBehaviour",
+                                    "required": null,
+                                    "description": "$[*Listing,Filter,Link] $help[Select how you want this component to behave. <br/> Listing: Default behavior <br/> Link: Every line uses a custom link and redirects upon clicking. <br/> Filter: allows the specification of a var and its value to be used across components in the dashboard.]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Help": {
+                                                "args": [
+                                                    "Select how you want this component to behave. <br/> Listing: Default behavior <br/> Link: Every line uses a custom link and redirects upon clicking. <br/> Filter: allows the specification of a var and its value to be used across components in the dashboard."
+                                                ]
+                                            },
+                                            "Select": {
+                                                "args": [
+                                                    "Listing",
+                                                    "Filter",
+                                                    "Link"
+                                                ],
+                                                "default": "Listing"
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "LineCustomize=Behaviour",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Behaviour"
+                                        ],
+                                        "matcher": {
+                                            "type": "Name",
+                                            "name": "LineCustomize"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [
+                                        {
+                                            "id": null,
+                                            "name": "FilterTotalValue",
+                                            "required": null,
+                                            "description": "The value of the filter $text",
+                                            "configuration": {
+                                                "description": "The value of the filter",
+                                                "keys": {},
+                                                "extensions": {
+                                                    "$text": {}
+                                                }
+                                            },
+                                            "condition": "=Filter",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Filter"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 58,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "FilterTotalVarName",
+                                            "required": null,
+                                            "description": "The filter variable name",
+                                            "configuration": {
+                                                "description": "The filter variable name",
+                                                "keys": {},
+                                                "extensions": {}
+                                            },
+                                            "condition": "=Filter",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Filter"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 59,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        },
+                                        {
+                                            "id": null,
+                                            "name": "LineLink",
+                                            "required": null,
+                                            "description": null,
+                                            "configuration": {
+                                                "description": null,
+                                                "keys": {},
+                                                "extensions": {}
+                                            },
+                                            "condition": "=Link",
+                                            "visibilityCondition": {
+                                                "type": "Equal",
+                                                "value": [
+                                                    "Link"
+                                                ],
+                                                "matcher": {
+                                                    "type": "Parent"
+                                                }
+                                            },
+                                            "duplicable": false,
+                                            "fields": [],
+                                            "order": 60,
+                                            "duplicablePath": true,
+                                            "restricted": false,
+                                            "rootField": false,
+                                            "defaultValue": null
+                                        }
+                                    ],
+                                    "order": 57,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "Listing"
+                                }
+                            ],
+                            "order": 45,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "KibanaCustomize",
+                            "required": null,
+                            "description": "$[Classes,InputVar,OutputVar,Query,TimeField] $multiple $help[Select the defaults to change] ",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "InputVar",
+                                            "OutputVar",
+                                            "Query",
+                                            "TimeField"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Kibana",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Kibana"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "KibanaClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 62,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InputVarKibana",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=InputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "InputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": true,
+                                    "fields": [],
+                                    "order": 63,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "OutputVarKibana",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=OutputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "OutputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 64,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InputQueryKibana",
+                                    "required": null,
+                                    "description": "Atenção: espaços no Kibana são OR e não AND",
+                                    "configuration": {
+                                        "description": "Atenção: espaços no Kibana são OR e não AND",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Query",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Query"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 65,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "KibanaTimeField",
+                                    "required": null,
+                                    "description": "The time field used by Kibana index used to filter the records",
+                                    "configuration": {
+                                        "description": "The time field used by Kibana index used to filter the records",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=TimeField",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "TimeField"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 66,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 61,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ShareLink",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Kibana",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Kibana"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 67,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "FilterCustomize",
+                            "required": null,
+                            "description": "$[Classes,noButton,Placeholder,EscapeSpecialChars] $multiple $help[Select the defaults to change<br><br><b>EscapeSpecialChars:</b> Escapes ElasticSearch chars in the filter]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change<br><br><b>EscapeSpecialChars:</b> Escapes ElasticSearch chars in the filter"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "noButton",
+                                            "Placeholder",
+                                            "EscapeSpecialChars"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Filter",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Filter"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "FilterClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 69,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Placeholder",
+                                    "required": null,
+                                    "description": "$default(Pesquisar...) default: Pesquisar...",
+                                    "configuration": {
+                                        "description": "default: Pesquisar...",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "Pesquisar..."
+                                                }
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Placeholder",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Placeholder"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 70,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "Pesquisar..."
+                                }
+                            ],
+                            "order": 68,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "OutputVarFilter",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Filter",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Filter"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 71,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Query",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=MD List",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "MD List"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 72,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "CalendarCustomize",
+                            "required": null,
+                            "description": "$[Classes,InputVar,OutputVar,Settings,CropMonth,HeaderOnly] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "InputVar",
+                                            "OutputVar",
+                                            "Settings",
+                                            "CropMonth",
+                                            "HeaderOnly"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Calendar",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Calendar"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "CalendarClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 74,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InputVarCalendar",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=InputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "InputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": true,
+                                    "fields": [],
+                                    "order": 75,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "MaxVisibleDayEvents",
+                                    "required": null,
+                                    "description": "$number(0) Specify the maximum number of events that will be visible before enabling the +more link. Set to -1 to list all events. Defaults to 3.",
+                                    "configuration": {
+                                        "description": "Specify the maximum number of events that will be visible before enabling the +more link. Set to -1 to list all events. Defaults to 3.",
+                                        "keys": {
+                                            "Number": {
+                                                "args": {
+                                                    "decimal_places": "0"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Settings",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Settings"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 76,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "AllowCreateInstances",
+                                    "required": null,
+                                    "description": "$[TRUE,FALSE] $default(FALSE)",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Select": {
+                                                "args": [
+                                                    "TRUE",
+                                                    "FALSE"
+                                                ],
+                                                "default": null
+                                            },
+                                            "Default": {
+                                                "args": {
+                                                    "value": "FALSE"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Settings",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Settings"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 77,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "FALSE"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "CreateDefinition",
+                                    "required": null,
+                                    "description": "Name of the Definition of Instances to Create",
+                                    "configuration": {
+                                        "description": "Name of the Definition of Instances to Create",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Settings",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Settings"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 78,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "EventViews",
+                                    "required": null,
+                                    "description": "List of views to show (first is default). Example: dayGridWeek,dayGridMonth,listMonth",
+                                    "configuration": {
+                                        "description": "List of views to show (first is default). Example: dayGridWeek,dayGridMonth,listMonth",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Settings",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Settings"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 79,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "OutputVarCalendar",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=OutputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "OutputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 80,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "OutputVarInterval",
+                                    "required": null,
+                                    "description": "$help[You can specify a name for a variable where the Calendar will insert two properties: startDate and endDate - respectively containing the current calendar's period's start and end dates in milliseconds]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Help": {
+                                                "args": [
+                                                    "You can specify a name for a variable where the Calendar will insert two properties: startDate and endDate - respectively containing the current calendar's period's start and end dates in milliseconds"
+                                                ]
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=OutputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "OutputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 81,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 73,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Events",
+                            "required": null,
+                            "description": "$group",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Group": {}
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Calendar",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Calendar"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": true,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "Definition",
+                                    "required": "mandatory",
+                                    "description": "$definition ",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$definition": {}
+                                        }
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 83,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "DateStartEventField",
+                                    "required": "mandatory",
+                                    "description": "Name of the definition date field that represents the beginning of the event ",
+                                    "configuration": {
+                                        "description": "Name of the definition date field that represents the beginning of the event",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 84,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "DateEndEventField",
+                                    "required": null,
+                                    "description": "Name of the definition date field that represents the end of the event ",
+                                    "configuration": {
+                                        "description": "Name of the definition date field that represents the end of the event",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 85,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "DescriptionEventField",
+                                    "required": "mandatory",
+                                    "description": "$text Name of the definition field to use as the event description ",
+                                    "configuration": {
+                                        "description": "Name of the definition field to use as the event description",
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 86,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "StateEventField",
+                                    "required": null,
+                                    "description": "'Name of the field to calculate the color for the event. If not defined it will use always the same color for all events. If starts with \"#\" that hex color will be used. If starts with \"bg:\" then it'll fill the background of that day with the color.'",
+                                    "configuration": {
+                                        "description": "'Name of the field to calculate the color for the event. If not defined it will use always the same color for all events. If starts with \"#\" that hex color will be used. If starts with \"bg:\" then it'll fill the background of that day with the color.'",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 87,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "EventsQuery",
+                                    "required": null,
+                                    "description": "Define a query to restrict the results that will appear in the calendar. Defaults to all records in the definition ",
+                                    "configuration": {
+                                        "description": "Define a query to restrict the results that will appear in the calendar. Defaults to all records in the definition",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 88,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "TooltipTemplate",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 89,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "AllDay",
+                                    "required": null,
+                                    "description": "$[True,*False] True if events occupy all day. False if otherwise.",
+                                    "configuration": {
+                                        "description": "True if events occupy all day. False if otherwise.",
+                                        "keys": {
+                                            "Select": {
+                                                "args": [
+                                                    "True",
+                                                    "False"
+                                                ],
+                                                "default": "False"
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": null,
+                                    "visibilityCondition": null,
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 90,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "False"
+                                }
+                            ],
+                            "order": 82,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ListCustomize",
+                            "required": null,
+                            "description": "$[InputVar,SetDefaultView,ShowViews,ShowActions,ShowImport,CreateAndDelete,Classes,HideRowSelection,HideDetailsColumn,HideColumnsSelector] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "InputVar",
+                                            "SetDefaultView",
+                                            "ShowViews",
+                                            "ShowActions",
+                                            "ShowImport",
+                                            "CreateAndDelete",
+                                            "Classes",
+                                            "HideRowSelection",
+                                            "HideDetailsColumn",
+                                            "HideColumnsSelector"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=List",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "List"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "InputVarList",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=InputVar",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "InputVar"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": true,
+                                    "fields": [],
+                                    "order": 92,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "DefaultView",
+                                    "required": null,
+                                    "description": "The default name of the view to use when showing the results",
+                                    "configuration": {
+                                        "description": "The default name of the view to use when showing the results",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=SetDefaultView",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "SetDefaultView"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 93,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "ListClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 94,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 91,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ListDefinition",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=List",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "List"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 95,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ListQuery",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=List",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "List"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 96,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Process",
+                            "required": null,
+                            "description": "$help[Instance ID of the business process]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Help": {
+                                        "args": [
+                                            "Instance ID of the business process"
+                                        ]
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Mermaid",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Mermaid"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 97,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "MermaidCustomize",
+                            "required": null,
+                            "description": "$[LinkClasses,DiagramClasses] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "LinkClasses",
+                                            "DiagramClasses"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Mermaid",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Mermaid"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "LinkClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=LinkClasses",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "LinkClasses"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 99,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "DiagramClasses",
+                                    "required": null,
+                                    "description": "$text",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=DiagramClasses",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "DiagramClasses"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 100,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 98,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ModalActivatorCustomize",
+                            "required": null,
+                            "description": "$[Classes] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=ModalActivator",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ModalActivator"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "ModalActivatorClasses",
+                                    "required": null,
+                                    "description": "$text $default(cursor-pointer text-blue-400 text-sm underline) default: cursor-pointer text-blue-400 text-sm underline ",
+                                    "configuration": {
+                                        "description": "default: cursor-pointer text-blue-400 text-sm underline",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "cursor-pointer text-blue-400 text-sm underline"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 102,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "cursor-pointer text-blue-400 text-sm underline"
+                                }
+                            ],
+                            "order": 101,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ModalBoardName",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=ModalActivator",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ModalActivator"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 103,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ModalActivatorText",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=ModalActivator",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ModalActivator"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 104,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "MarkdownCustomize",
+                            "required": null,
+                            "description": "$[Classes,Mode] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "Mode"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Markdown",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Markdown"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "MarkdownClasses",
+                                    "required": null,
+                                    "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
+                                    "configuration": {
+                                        "description": "Default: text-justify text-gray-700",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-justify text-gray-700"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 106,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-justify text-gray-700"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Mode",
+                                    "required": null,
+                                    "description": "$[*Light,Dark] $radio ",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Select": {
+                                                "args": [
+                                                    "Light",
+                                                    "Dark"
+                                                ],
+                                                "default": "Light"
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$radio": {}
+                                        }
+                                    },
+                                    "condition": "=Mode",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Mode"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 107,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "Light"
+                                }
+                            ],
+                            "order": 105,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "MDContent",
+                            "required": null,
+                            "description": "$markdown",
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {
+                                    "$markdown": {}
+                                }
+                            },
+                            "condition": "=Markdown",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Markdown"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 108,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "SlidesCustomize",
+                            "required": null,
+                            "description": "$[Classes,EndOfContentTrigger] $multiple $help[Select the defaults to change] $help['EndOfContentTrigger' to configure end of slides update. False if you want to ONLY SHOW contents]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "'EndOfContentTrigger'",
+                                            "to configure end of slides update. False if you want to ONLY SHOW contents"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "EndOfContentTrigger"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Slides",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Slides"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "SlidesClasses",
+                                    "required": null,
+                                    "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
+                                    "configuration": {
+                                        "description": "Default: text-justify text-gray-700",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-justify text-gray-700"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 110,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-justify text-gray-700"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "ConcurrentScript",
+                                    "required": null,
+                                    "description": "$help[If you don't specify a concurrent script, Slides will ONLY show the content.]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Help": {
+                                                "args": [
+                                                    "If you don't specify a concurrent script",
+                                                    "Slides will ONLY show the content."
+                                                ]
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=EndOfContentTrigger",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "EndOfContentTrigger"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 111,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "SlidesArg",
+                                    "required": null,
+                                    "description": null,
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=EndOfContentTrigger",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "EndOfContentTrigger"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 112,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 109,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "Content",
+                            "required": null,
+                            "description": "$markdown",
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {
+                                    "$markdown": {}
+                                }
+                            },
+                            "condition": "=Slides",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Slides"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 113,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "HierarchyCustomize",
+                            "required": null,
+                            "description": "$[Classes] $multiple $help[Select the defaults to change]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Help": {
+                                        "args": [
+                                            "Select the defaults to change"
+                                        ]
+                                    },
+                                    "Select": {
+                                        "args": [
+                                            "Classes"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "HierarchyNodeClasses",
+                                    "required": null,
+                                    "description": " $text $default(text-red-500 font-bold) Default: text-red-500 font-bold",
+                                    "configuration": {
+                                        "description": "Default: text-red-500 font-bold",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-red-500 font-bold"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 115,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-red-500 font-bold"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "HierarchyRowClasses",
+                                    "required": null,
+                                    "description": "$text $default(text-stone-600) Default: text-stone-600",
+                                    "configuration": {
+                                        "description": "Default: text-stone-600",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-stone-600"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 116,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-stone-600"
+                                }
+                            ],
+                            "order": 114,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "InputVarHierarchy",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 117,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "OutputVarHierarchy",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 118,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ParentFieldName",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 119,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "SortFieldName",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 120,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "DefinitionNameHierarchy",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 121,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "FilterHierarchy",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 122,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "DisplayFieldHierarchy",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 123,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "InstanceFieldNameHierarchy",
+                            "required": null,
+                            "description": "$help[You can specify a instance's field name to output its value instead of the entire object.]",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Help": {
+                                        "args": [
+                                            "You can specify a instance's field name to output its value instead of the entire object."
+                                        ]
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Hierarchy",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Hierarchy"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 124,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "File",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Viewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Viewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 125,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ViewerCustomize",
+                            "required": null,
+                            "description": "$[Classes] $multiple",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Select": {
+                                        "args": [
+                                            "Classes"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=Viewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Viewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "ViewerClasses",
+                                    "required": null,
+                                    "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
+                                    "configuration": {
+                                        "description": "Default: text-justify text-gray-700",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "text-justify text-gray-700"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 127,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "text-justify text-gray-700"
+                                }
+                            ],
+                            "order": 126,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "OutputVarViewer",
+                            "required": null,
+                            "description": "Extracted text from OCR or QR Code",
+                            "configuration": {
+                                "description": "Extracted text from OCR or QR Code",
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=Viewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "Viewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 128,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ImageViewerCustomize",
+                            "required": null,
+                            "description": "$[Classes,Tag,Buttons] $multiple",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "Tag",
+                                            "Buttons"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=ImageViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ImageViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "ImageViewerClasses",
+                                    "required": null,
+                                    "description": "$text $default(max-h-[70vh]) Default: max-h-[70vh] $help(Classes for the image viewer container) ",
+                                    "configuration": {
+                                        "description": "Default: max-h-[70vh]",
+                                        "keys": {
+                                            "Help": {
+                                                "args": [
+                                                    "Classes for the image viewer container"
+                                                ]
+                                            },
+                                            "Default": {
+                                                "args": {
+                                                    "value": "max-h-[70vh]"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 130,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "max-h-[70vh]"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "ImageViewerButtonClasses",
+                                    "required": null,
+                                    "description": "$text $default(bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer) $help(Classes for the image viewer buttons) ",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Help": {
+                                                "args": [
+                                                    "Classes for the image viewer buttons"
+                                                ]
+                                            },
+                                            "Default": {
+                                                "args": {
+                                                    "value": "bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 131,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "ImageViewerIdentifier",
+                                    "required": null,
+                                    "description": "Identifier for Image Viewer Component",
+                                    "configuration": {
+                                        "description": "Identifier for Image Viewer Component",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Tag",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Tag"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 132,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                },
+                                {
+                                    "id": null,
+                                    "name": "Enable Buttons",
+                                    "required": null,
+                                    "description": "$multiple $[Zoom In/Out,Mode Switch,Rotate,OCR]",
+                                    "configuration": {
+                                        "description": null,
+                                        "keys": {
+                                            "Multiple": {},
+                                            "Select": {
+                                                "args": [
+                                                    "Zoom In/Out",
+                                                    "Mode Switch",
+                                                    "Rotate",
+                                                    "OCR"
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Buttons",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Buttons"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 133,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 129,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "OutputVarImageViewer",
+                            "required": null,
+                            "description": "Extracted text from OCR or QR Code",
+                            "configuration": {
+                                "description": "Extracted text from OCR or QR Code",
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=ImageViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ImageViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 134,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "ImageViewerURL",
+                            "required": null,
+                            "description": "Image URL $text",
+                            "configuration": {
+                                "description": "Image URL",
+                                "keys": {},
+                                "extensions": {
+                                    "$text": {}
+                                }
+                            },
+                            "condition": "=ImageViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "ImageViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": true,
+                            "fields": [],
+                            "order": 135,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "InstanceViewerCustomize",
+                            "required": null,
+                            "description": "$[Classes,Tag,HideSidenav] $multiple",
+                            "configuration": {
+                                "description": null,
+                                "keys": {
+                                    "Multiple": {},
+                                    "Select": {
+                                        "args": [
+                                            "Classes",
+                                            "Tag",
+                                            "HideSidenav"
+                                        ],
+                                        "default": null
+                                    }
+                                },
+                                "extensions": {}
+                            },
+                            "condition": "=InstanceViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "InstanceViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [
+                                {
+                                    "id": null,
+                                    "name": "NoInstanceClasses",
+                                    "required": null,
+                                    "description": "$text $default(w-full text-center text-xl text-stone-400 font-bold self-center) Default: w-full text-center text-xl text-stone-400 font-bold self-center",
+                                    "configuration": {
+                                        "description": "Default: w-full text-center text-xl text-stone-400 font-bold self-center",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "w-full text-center text-xl text-stone-400 font-bold self-center"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 137,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "w-full text-center text-xl text-stone-400 font-bold self-center"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InstanceViewerClasses",
+                                    "required": null,
+                                    "description": "$text $default(flex w-full h-full max-h-[70vh]) Default: flex w-full h-full max-h-[70vh]",
+                                    "configuration": {
+                                        "description": "Default: flex w-full h-full max-h-[70vh]",
+                                        "keys": {
+                                            "Default": {
+                                                "args": {
+                                                    "value": "flex w-full h-full max-h-[70vh]"
+                                                }
+                                            }
+                                        },
+                                        "extensions": {
+                                            "$text": {}
+                                        }
+                                    },
+                                    "condition": "=Classes",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Classes"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 138,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": "flex w-full h-full max-h-[70vh]"
+                                },
+                                {
+                                    "id": null,
+                                    "name": "InstanceViewerIdentifier",
+                                    "required": null,
+                                    "description": "Identifier for Instance Viewer Component",
+                                    "configuration": {
+                                        "description": "Identifier for Instance Viewer Component",
+                                        "keys": {},
+                                        "extensions": {}
+                                    },
+                                    "condition": "=Tag",
+                                    "visibilityCondition": {
+                                        "type": "Equal",
+                                        "value": [
+                                            "Tag"
+                                        ],
+                                        "matcher": {
+                                            "type": "Parent"
+                                        }
+                                    },
+                                    "duplicable": false,
+                                    "fields": [],
+                                    "order": 139,
+                                    "duplicablePath": true,
+                                    "restricted": false,
+                                    "rootField": false,
+                                    "defaultValue": null
+                                }
+                            ],
+                            "order": 136,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "InstanceViewerInstanceId",
+                            "required": null,
+                            "description": "ID of the instance to show",
+                            "configuration": {
+                                "description": "ID of the instance to show",
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=InstanceViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "InstanceViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 140,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
+                        },
+                        {
+                            "id": null,
+                            "name": "InstanceViewerOutputVar",
+                            "required": null,
+                            "description": null,
+                            "configuration": {
+                                "description": null,
+                                "keys": {},
+                                "extensions": {}
+                            },
+                            "condition": "=InstanceViewer",
+                            "visibilityCondition": {
+                                "type": "Equal",
+                                "value": [
+                                    "InstanceViewer"
+                                ],
+                                "matcher": {
+                                    "type": "Parent"
+                                }
+                            },
+                            "duplicable": false,
+                            "fields": [],
+                            "order": 141,
+                            "duplicablePath": true,
+                            "restricted": false,
+                            "rootField": false,
+                            "defaultValue": null
                         }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 58,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    },
-                    {
-                      "id": null,
-                      "name": "FilterTotalVarName",
-                      "required": null,
-                      "description": "The filter variable name",
-                      "configuration": {
-                        "description": "The filter variable name",
-                        "keys": {},
-                        "extensions": {}
-                      },
-                      "condition": "=Filter",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Filter"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 59,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    },
-                    {
-                      "id": null,
-                      "name": "LineLink",
-                      "required": null,
-                      "description": null,
-                      "configuration": {
-                        "description": null,
-                        "keys": {},
-                        "extensions": {}
-                      },
-                      "condition": "=Link",
-                      "visibilityCondition": {
-                        "type": "Equal",
-                        "value": [
-                          "Link"
-                        ],
-                        "matcher": {
-                          "type": "Parent"
-                        }
-                      },
-                      "duplicable": false,
-                      "fields": [],
-                      "order": 60,
-                      "restricted": false,
-                      "rootField": false,
-                      "defaultValue": null
-                    }
-                  ],
-                  "order": 57,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "Listing"
-                }
-              ],
-              "order": 45,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "KibanaCustomize",
-              "required": null,
-              "description": "$[Classes,InputVar,OutputVar,Query,TimeField] $multiple $help[Select the defaults to change] ",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "InputVar",
-                      "OutputVar",
-                      "Query",
-                      "TimeField"
                     ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Kibana",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Kibana"
-                ],
-                "matcher": {
-                  "type": "Parent"
+                    "order": 27,
+                    "duplicablePath": true,
+                    "restricted": false,
+                    "rootField": false,
+                    "defaultValue": null
                 }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "KibanaClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 62,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "InputVarKibana",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=InputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "InputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": true,
-                  "fields": [],
-                  "order": 63,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "OutputVarKibana",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=OutputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "OutputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 64,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "InputQueryKibana",
-                  "required": null,
-                  "description": "Atenção: espaços no Kibana são OR e não AND",
-                  "configuration": {
-                    "description": "Atenção: espaços no Kibana são OR e não AND",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=Query",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Query"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 65,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "KibanaTimeField",
-                  "required": null,
-                  "description": "The time field used by Kibana index used to filter the records",
-                  "configuration": {
-                    "description": "The time field used by Kibana index used to filter the records",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=TimeField",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "TimeField"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 66,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 61,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ShareLink",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Kibana",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Kibana"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 67,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "FilterCustomize",
-              "required": null,
-              "description": "$[Classes,noButton,Placeholder,EscapeSpecialChars] $multiple $help[Select the defaults to change<br><br><b>EscapeSpecialChars:</b> Escapes ElasticSearch chars in the filter]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "noButton",
-                      "Placeholder",
-                      "EscapeSpecialChars"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change<br><br><b>EscapeSpecialChars:</b> Escapes ElasticSearch chars in the filter"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Filter",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Filter"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "FilterClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 69,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "Placeholder",
-                  "required": null,
-                  "description": "$default(Pesquisar...) default: Pesquisar...",
-                  "configuration": {
-                    "description": "default: Pesquisar...",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "Pesquisar..."
-                        }
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=Placeholder",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Placeholder"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 70,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "Pesquisar..."
-                }
-              ],
-              "order": 68,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "OutputVarFilter",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Filter",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Filter"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 71,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Query",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=MD List",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "MD List"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 72,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "CalendarCustomize",
-              "required": null,
-              "description": "$[Classes,InputVar,OutputVar,Settings,CropMonth,HeaderOnly] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "InputVar",
-                      "OutputVar",
-                      "Settings",
-                      "CropMonth",
-                      "HeaderOnly"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Calendar",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Calendar"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "CalendarClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 74,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "InputVarCalendar",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=InputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "InputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": true,
-                  "fields": [],
-                  "order": 75,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "MaxVisibleDayEvents",
-                  "required": null,
-                  "description": "$number(0) Specify the maximum number of events that will be visible before enabling the +more link. Set to -1 to list all events. Defaults to 3.",
-                  "configuration": {
-                    "description": "Specify the maximum number of events that will be visible before enabling the +more link. Set to -1 to list all events. Defaults to 3.",
-                    "keys": {
-                      "Number": {
-                        "args": {
-                          "decimal_places": "0"
-                        }
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=Settings",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Settings"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 76,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "AllowCreateInstances",
-                  "required": null,
-                  "description": "$[TRUE,FALSE] $default(FALSE)",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "FALSE"
-                        }
-                      },
-                      "Select": {
-                        "args": [
-                          "TRUE",
-                          "FALSE"
-                        ],
-                        "default": null
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=Settings",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Settings"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 77,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "FALSE"
-                },
-                {
-                  "id": null,
-                  "name": "CreateDefinition",
-                  "required": null,
-                  "description": "Name of the Definition of Instances to Create",
-                  "configuration": {
-                    "description": "Name of the Definition of Instances to Create",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=Settings",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Settings"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 78,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "EventViews",
-                  "required": null,
-                  "description": "List of views to show (first is default). Example: dayGridWeek,dayGridMonth,listMonth",
-                  "configuration": {
-                    "description": "List of views to show (first is default). Example: dayGridWeek,dayGridMonth,listMonth",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=Settings",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Settings"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 79,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "OutputVarCalendar",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=OutputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "OutputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 80,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "OutputVarInterval",
-                  "required": null,
-                  "description": "$help[You can specify a name for a variable where the Calendar will insert two properties: startDate and endDate - respectively containing the current calendar's period's start and end dates in milliseconds]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Help": {
-                        "args": [
-                          "You can specify a name for a variable where the Calendar will insert two properties: startDate and endDate - respectively containing the current calendar's period's start and end dates in milliseconds"
-                        ]
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=OutputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "OutputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 81,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 73,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Events",
-              "required": null,
-              "description": "$group",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Group": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Calendar",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Calendar"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": true,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "Definition",
-                  "required": "mandatory",
-                  "description": "$definition ",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$definition": {}
-                    }
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 83,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "DateStartEventField",
-                  "required": "mandatory",
-                  "description": "Name of the definition date field that represents the beginning of the event ",
-                  "configuration": {
-                    "description": "Name of the definition date field that represents the beginning of the event",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 84,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "DateEndEventField",
-                  "required": null,
-                  "description": "Name of the definition date field that represents the end of the event ",
-                  "configuration": {
-                    "description": "Name of the definition date field that represents the end of the event",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 85,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "DescriptionEventField",
-                  "required": "mandatory",
-                  "description": "$text Name of the definition field to use as the event description ",
-                  "configuration": {
-                    "description": "Name of the definition field to use as the event description",
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 86,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "StateEventField",
-                  "required": null,
-                  "description": "'Name of the field to calculate the color for the event. If not defined it will use always the same color for all events. If starts with \"#\" that hex color will be used. If starts with \"bg:\" then it'll fill the background of that day with the color.'",
-                  "configuration": {
-                    "description": "'Name of the field to calculate the color for the event. If not defined it will use always the same color for all events. If starts with \"#\" that hex color will be used. If starts with \"bg:\" then it'll fill the background of that day with the color.'",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 87,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "EventsQuery",
-                  "required": null,
-                  "description": "Define a query to restrict the results that will appear in the calendar. Defaults to all records in the definition ",
-                  "configuration": {
-                    "description": "Define a query to restrict the results that will appear in the calendar. Defaults to all records in the definition",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 88,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "TooltipTemplate",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 89,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "AllDay",
-                  "required": null,
-                  "description": "$[True,*False] True if events occupy all day. False if otherwise.",
-                  "configuration": {
-                    "description": "True if events occupy all day. False if otherwise.",
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "True",
-                          "False"
-                        ],
-                        "default": "False"
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": null,
-                  "visibilityCondition": null,
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 90,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "False"
-                }
-              ],
-              "order": 82,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ListCustomize",
-              "required": null,
-              "description": "$[InputVar,SetDefaultView,ShowViews,ShowActions,ShowImport,CreateAndDelete,Classes,HideRowSelection,HideDetailsColumn,HideColumnsSelector] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "InputVar",
-                      "SetDefaultView",
-                      "ShowViews",
-                      "ShowActions",
-                      "ShowImport",
-                      "CreateAndDelete",
-                      "Classes",
-                      "HideRowSelection",
-                      "HideDetailsColumn",
-                      "HideColumnsSelector"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=List",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "List"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "InputVarList",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=InputVar",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "InputVar"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": true,
-                  "fields": [],
-                  "order": 92,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "DefaultView",
-                  "required": null,
-                  "description": "The default name of the view to use when showing the results",
-                  "configuration": {
-                    "description": "The default name of the view to use when showing the results",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=SetDefaultView",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "SetDefaultView"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 93,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "ListClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 94,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 91,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ListDefinition",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=List",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "List"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 95,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ListQuery",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=List",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "List"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 96,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Process",
-              "required": null,
-              "description": "$help[Instance ID of the business process]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Help": {
-                    "args": [
-                      "Instance ID of the business process"
-                    ]
-                  }
-                },
-                "extensions": {}
-              },
-              "condition": "=Mermaid",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Mermaid"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 97,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "MermaidCustomize",
-              "required": null,
-              "description": "$[LinkClasses,DiagramClasses] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "LinkClasses",
-                      "DiagramClasses"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Mermaid",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Mermaid"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "LinkClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=LinkClasses",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "LinkClasses"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 99,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "DiagramClasses",
-                  "required": null,
-                  "description": "$text",
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=DiagramClasses",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "DiagramClasses"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 100,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 98,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ModalActivatorCustomize",
-              "required": null,
-              "description": "$[Classes] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=ModalActivator",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ModalActivator"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "ModalActivatorClasses",
-                  "required": null,
-                  "description": "$text $default(cursor-pointer text-blue-400 text-sm underline) default: cursor-pointer text-blue-400 text-sm underline ",
-                  "configuration": {
-                    "description": "default: cursor-pointer text-blue-400 text-sm underline",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "cursor-pointer text-blue-400 text-sm underline"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 102,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "cursor-pointer text-blue-400 text-sm underline"
-                }
-              ],
-              "order": 101,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ModalBoardName",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=ModalActivator",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ModalActivator"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 103,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ModalActivatorText",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=ModalActivator",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ModalActivator"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 104,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "MarkdownCustomize",
-              "required": null,
-              "description": "$[Classes,Mode] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "Mode"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Markdown",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Markdown"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "MarkdownClasses",
-                  "required": null,
-                  "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
-                  "configuration": {
-                    "description": "Default: text-justify text-gray-700",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-justify text-gray-700"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 106,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-justify text-gray-700"
-                },
-                {
-                  "id": null,
-                  "name": "Mode",
-                  "required": null,
-                  "description": "$[*Light,Dark] $radio ",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "Light",
-                          "Dark"
-                        ],
-                        "default": "Light"
-                      }
-                    },
-                    "extensions": {
-                      "$radio": {}
-                    }
-                  },
-                  "condition": "=Mode",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Mode"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 107,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "Light"
-                }
-              ],
-              "order": 105,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "MDContent",
-              "required": null,
-              "description": "$markdown",
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {
-                  "$markdown": {}
-                }
-              },
-              "condition": "=Markdown",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Markdown"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 108,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "SlidesCustomize",
-              "required": null,
-              "description": "$[Classes,EndOfContentTrigger] $multiple $help[Select the defaults to change] $help['EndOfContentTrigger' to configure end of slides update. False if you want to ONLY SHOW contents]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "EndOfContentTrigger"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "'EndOfContentTrigger'",
-                      "to configure end of slides update. False if you want to ONLY SHOW contents"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Slides",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Slides"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "SlidesClasses",
-                  "required": null,
-                  "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
-                  "configuration": {
-                    "description": "Default: text-justify text-gray-700",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-justify text-gray-700"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 110,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-justify text-gray-700"
-                },
-                {
-                  "id": null,
-                  "name": "ConcurrentScript",
-                  "required": null,
-                  "description": "$help[If you don't specify a concurrent script, Slides will ONLY show the content.]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Help": {
-                        "args": [
-                          "If you don't specify a concurrent script",
-                          "Slides will ONLY show the content."
-                        ]
-                      }
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=EndOfContentTrigger",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "EndOfContentTrigger"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 111,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "SlidesArg",
-                  "required": null,
-                  "description": null,
-                  "configuration": {
-                    "description": null,
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=EndOfContentTrigger",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "EndOfContentTrigger"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 112,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 109,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "Content",
-              "required": null,
-              "description": "$markdown",
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {
-                  "$markdown": {}
-                }
-              },
-              "condition": "=Slides",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Slides"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 113,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "HierarchyCustomize",
-              "required": null,
-              "description": "$[Classes] $multiple $help[Select the defaults to change]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes"
-                    ],
-                    "default": null
-                  },
-                  "Help": {
-                    "args": [
-                      "Select the defaults to change"
-                    ]
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "HierarchyNodeClasses",
-                  "required": null,
-                  "description": " $text $default(text-red-500 font-bold) Default: text-red-500 font-bold",
-                  "configuration": {
-                    "description": "Default: text-red-500 font-bold",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-red-500 font-bold"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 115,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-red-500 font-bold"
-                },
-                {
-                  "id": null,
-                  "name": "HierarchyRowClasses",
-                  "required": null,
-                  "description": "$text $default(text-stone-600) Default: text-stone-600",
-                  "configuration": {
-                    "description": "Default: text-stone-600",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-stone-600"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 116,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-stone-600"
-                }
-              ],
-              "order": 114,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "InputVarHierarchy",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 117,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "OutputVarHierarchy",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 118,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ParentFieldName",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 119,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "SortFieldName",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 120,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "DefinitionNameHierarchy",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 121,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "FilterHierarchy",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 122,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "DisplayFieldHierarchy",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 123,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "InstanceFieldNameHierarchy",
-              "required": null,
-              "description": "$help[You can specify a instance's field name to output its value instead of the entire object.]",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Help": {
-                    "args": [
-                      "You can specify a instance's field name to output its value instead of the entire object."
-                    ]
-                  }
-                },
-                "extensions": {}
-              },
-              "condition": "=Hierarchy",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Hierarchy"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 124,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "File",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Viewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Viewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 125,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ViewerCustomize",
-              "required": null,
-              "description": "$[Classes] $multiple",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes"
-                    ],
-                    "default": null
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=Viewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Viewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "ViewerClasses",
-                  "required": null,
-                  "description": "$text $default(text-justify text-gray-700) Default: text-justify text-gray-700 ",
-                  "configuration": {
-                    "description": "Default: text-justify text-gray-700",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "text-justify text-gray-700"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 127,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "text-justify text-gray-700"
-                }
-              ],
-              "order": 126,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "OutputVarViewer",
-              "required": null,
-              "description": "Extracted text from OCR or QR Code",
-              "configuration": {
-                "description": "Extracted text from OCR or QR Code",
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=Viewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "Viewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 128,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ImageViewerCustomize",
-              "required": null,
-              "description": "$[Classes,Tag,Buttons] $multiple",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "Tag",
-                      "Buttons"
-                    ],
-                    "default": null
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=ImageViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ImageViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "ImageViewerClasses",
-                  "required": null,
-                  "description": "$text $default(max-h-[70vh]) Default: max-h-[70vh] $help(Classes for the image viewer container) ",
-                  "configuration": {
-                    "description": "Default: max-h-[70vh]",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "max-h-[70vh]"
-                        }
-                      },
-                      "Help": {
-                        "args": [
-                          "Classes for the image viewer container"
-                        ]
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 130,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "max-h-[70vh]"
-                },
-                {
-                  "id": null,
-                  "name": "ImageViewerButtonClasses",
-                  "required": null,
-                  "description": "$text $default(bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer) $help(Classes for the image viewer buttons) ",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer"
-                        }
-                      },
-                      "Help": {
-                        "args": [
-                          "Classes for the image viewer buttons"
-                        ]
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 131,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "bg-blue-600 text-stone-200 font-light  border-2 text-sm border-stone-800 px-2 py-1 hover:bg-blue-400 hover:cursor-pointer"
-                },
-                {
-                  "id": null,
-                  "name": "ImageViewerIdentifier",
-                  "required": null,
-                  "description": "Identifier for Image Viewer Component",
-                  "configuration": {
-                    "description": "Identifier for Image Viewer Component",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=Tag",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Tag"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 132,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                },
-                {
-                  "id": null,
-                  "name": "Enable Buttons",
-                  "required": null,
-                  "description": "$multiple $[Zoom In/Out,Mode Switch,Rotate,OCR]",
-                  "configuration": {
-                    "description": null,
-                    "keys": {
-                      "Select": {
-                        "args": [
-                          "Zoom In/Out",
-                          "Mode Switch",
-                          "Rotate",
-                          "OCR"
-                        ],
-                        "default": null
-                      },
-                      "Multiple": {}
-                    },
-                    "extensions": {}
-                  },
-                  "condition": "=Buttons",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Buttons"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 133,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 129,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "OutputVarImageViewer",
-              "required": null,
-              "description": "Extracted text from OCR or QR Code",
-              "configuration": {
-                "description": "Extracted text from OCR or QR Code",
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=ImageViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ImageViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 134,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "ImageViewerURL",
-              "required": null,
-              "description": "Image URL",
-              "configuration": {
-                "description": "Image URL",
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=ImageViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "ImageViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 135,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "InstanceViewerCustomize",
-              "required": null,
-              "description": "$[Classes,Tag,HideSidenav] $multiple",
-              "configuration": {
-                "description": null,
-                "keys": {
-                  "Select": {
-                    "args": [
-                      "Classes",
-                      "Tag",
-                      "HideSidenav"
-                    ],
-                    "default": null
-                  },
-                  "Multiple": {}
-                },
-                "extensions": {}
-              },
-              "condition": "=InstanceViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "InstanceViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [
-                {
-                  "id": null,
-                  "name": "NoInstanceClasses",
-                  "required": null,
-                  "description": "$text $default(w-full text-center text-xl text-stone-400 font-bold self-center) Default: w-full text-center text-xl text-stone-400 font-bold self-center",
-                  "configuration": {
-                    "description": "Default: w-full text-center text-xl text-stone-400 font-bold self-center",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "w-full text-center text-xl text-stone-400 font-bold self-center"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 137,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "w-full text-center text-xl text-stone-400 font-bold self-center"
-                },
-                {
-                  "id": null,
-                  "name": "InstanceViewerClasses",
-                  "required": null,
-                  "description": "$text $default(flex w-full h-full max-h-[70vh]) Default: flex w-full h-full max-h-[70vh]",
-                  "configuration": {
-                    "description": "Default: flex w-full h-full max-h-[70vh]",
-                    "keys": {
-                      "Default": {
-                        "args": {
-                          "value": "flex w-full h-full max-h-[70vh]"
-                        }
-                      }
-                    },
-                    "extensions": {
-                      "$text": {}
-                    }
-                  },
-                  "condition": "=Classes",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Classes"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 138,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": "flex w-full h-full max-h-[70vh]"
-                },
-                {
-                  "id": null,
-                  "name": "InstanceViewerIdentifier",
-                  "required": null,
-                  "description": "Identifier for Instance Viewer Component",
-                  "configuration": {
-                    "description": "Identifier for Instance Viewer Component",
-                    "keys": {},
-                    "extensions": {}
-                  },
-                  "condition": "=Tag",
-                  "visibilityCondition": {
-                    "type": "Equal",
-                    "value": [
-                      "Tag"
-                    ],
-                    "matcher": {
-                      "type": "Parent"
-                    }
-                  },
-                  "duplicable": false,
-                  "fields": [],
-                  "order": 139,
-                  "restricted": false,
-                  "rootField": false,
-                  "defaultValue": null
-                }
-              ],
-              "order": 136,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "InstanceViewerInstanceId",
-              "required": null,
-              "description": "ID of the instance to show",
-              "configuration": {
-                "description": "ID of the instance to show",
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=InstanceViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "InstanceViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 140,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            },
-            {
-              "id": null,
-              "name": "InstanceViewerOutputVar",
-              "required": null,
-              "description": null,
-              "configuration": {
-                "description": null,
-                "keys": {},
-                "extensions": {}
-              },
-              "condition": "=InstanceViewer",
-              "visibilityCondition": {
-                "type": "Equal",
-                "value": [
-                  "InstanceViewer"
-                ],
-                "matcher": {
-                  "type": "Parent"
-                }
-              },
-              "duplicable": false,
-              "fields": [],
-              "order": 141,
-              "restricted": false,
-              "rootField": false,
-              "defaultValue": null
-            }
-          ],
-          "order": 27,
-          "restricted": false,
-          "rootField": false,
-          "defaultValue": null
+            ],
+            "order": 23,
+            "duplicablePath": true,
+            "restricted": false,
+            "rootField": true,
+            "defaultValue": null
         }
-      ],
-      "order": 23,
-      "restricted": false,
-      "rootField": true,
-      "defaultValue": null
-    }
-  ],
-  "version": null
+    ],
+    "version": null
 }

--- a/recordm/customUI/dash/src/collector.js
+++ b/recordm/customUI/dash/src/collector.js
@@ -231,7 +231,7 @@ function parseDashboard(raw_dashboard) {
                 "Enable Buttons":""
             }],
             "OutputVarImageViewer":"",
-            "ImageViewerURL":""
+            "ImageViewerURL":[{}]
         },
         "InstanceViewer" : {
             "InstanceViewerCustomize": [{


### PR DESCRIPTION
- ImageViewerURL field is now a duplicatable
    - Supports #each HBS block to dynamically send a list of image urls to the component
    - Meaning the component receives a list of image URLs and using an internal list index we traverse those images to know which one to show currently.
```
{{#each this.imagens}} 
/recordm/recordm/instances/{{@root.currDoc.value.0.id}}/files/{{@root.imgFieldId}}/{{this}}
```
- Adds pagination with arrows and "page" number.